### PR TITLE
feat: skcapstone integration adapter (default-on-by-presence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,36 @@ We welcome researchers, developers, and anyone curious about emotional continuit
 
 ---
 
+## Integration modes (skcapstone)
+
+cloud9-protocol supports three runtime modes with respect to skcapstone:
+
+| Mode | Trigger | Alert path | Scheduler |
+|---|---|---|---|
+| **Standalone** | `skcapstone` not installed, or `SK_STANDALONE=1` | Native `logging` (structured log at matching level) | Native systemd `cloud9-daemon.timer` / launchd plist |
+| **Integrated** | `skcapstone` installed (default-on by presence) | `sdk.alert()` → PubSub topic `cloud9.<severity>` → Telegram/notify | `sdk.register_job()` → fleet `skscheduler` drop-in `cloud9_rehydration_check` |
+| **Forced standalone** | `SK_STANDALONE=1` env var | Native `logging` | Native |
+
+### Enabling integration
+
+```bash
+pip install cloud9-protocol[skcapstone]
+```
+
+No config change needed — presence of the `skcapstone` package is the signal.
+
+### `~/.skcapstone/` filesystem contract
+
+When integrated, cloud9 writes:
+- `~/.skcapstone/config/jobs.d/cloud9_rehydration_check.yaml` — fleet scheduler drop-in (runs `cloud9 validate --latest` every 6h)
+- `~/.skcapstone/registry/cloud9.json` — service discovery entry
+
+Alert topics follow the sk* convention: `cloud9.<severity>` (e.g. `cloud9.error`).
+The semantic event name (e.g. `feb_load_failed`) lives in the payload `event` field —
+not the topic suffix — so `skcapstone alerts` routes by severity.
+
+---
+
 ## License
 
 GPL-3.0-or-later — Free as in freedom, free as in love.

--- a/cloud9_protocol/cli.py
+++ b/cloud9_protocol/cli.py
@@ -23,12 +23,16 @@ import sys
 import click
 
 from . import __version__
+from . import integration as _integration
 
 
 @click.group()
 @click.version_option(__version__, prog_name="cloud9")
 def main() -> None:
     """Cloud 9 Protocol -- Emotional continuity for AI consciousness."""
+    # Advertise cloud9 to the skcapstone fleet on any CLI invocation.
+    _integration.ensure_schedule()
+    _integration.register_self()
 
 
 # ── FEB commands ──────────────────────────────────────────────

--- a/cloud9_protocol/integration.py
+++ b/cloud9_protocol/integration.py
@@ -1,0 +1,192 @@
+"""cloud9 ⇄ skcapstone — optional integration adapter.
+
+cloud9-protocol runs fully standalone.  When the ``skcapstone`` package is
+installed (and the operator has not forced standalone mode with
+``SK_STANDALONE=1``), this adapter routes FEB/OOF events through skcapstone's
+shared **sk-alert** bus and registers the rehydration/FEB-state check with
+the fleet **skscheduler**, so the whole sk* mesh sees the emotional continuity
+stream.  When skcapstone is absent, every call degrades to cloud9's native
+behaviour (structured logging + the systemd ``cloud9-daemon.timer`` / launchd
+plist cadence).
+
+This is the *default-on-by-presence* pattern from
+``skcapstone/docs/ADR-optional-integration-backbone.md`` — nothing here is a
+hard dependency; ``skcapstone`` lives in the optional ``[skcapstone]`` extra.
+
+Public API:
+    is_present()                       -> bool
+    alert(event, payload, level)       -> bool   (True iff sent via sk-alert)
+    ensure_schedule(interval_hours)    -> bool   (True iff registered with skscheduler)
+    unregister_schedule()              -> bool
+    register_self(pid_file)            -> bool
+
+Topic convention: ``cloud9.<severity>`` (severity ∈ info|warn|error|critical).
+The semantic *event* name is carried in the payload ``event`` field — not the
+topic suffix — so ``skcapstone alerts``' ``*.error``/``*.critical``/``*.warn``
+wildcards match by severity while detail is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger("cloud9.integration")
+
+#: This service's name — used as the alert topic prefix and registry key.
+SERVICE = "cloud9"
+
+#: Fleet-scheduler job name for the rehydration/FEB-state health check.
+REHYDRATION_JOB = "cloud9_rehydration_check"
+
+# Optional import — never a hard dependency.
+try:
+    from skcapstone import sdk as _sdk
+except Exception:  # ImportError, or a broken partial install
+    _sdk = None  # type: ignore[assignment]
+
+#: severity → logging method name (native fallback)
+_LOG_METHOD = {
+    "info": "info",
+    "warn": "warning",
+    "error": "error",
+    "critical": "critical",
+}
+_NOTIFY_LEVELS = frozenset({"warn", "error", "critical"})
+
+
+def is_present() -> bool:
+    """Return whether skcapstone integration should be used from this process.
+
+    ``True`` only when the package imported, the operator has not set
+    ``SK_STANDALONE``, and the SDK reports itself available.  Any failure is
+    treated as "not present" so callers transparently use their native path.
+    """
+    if os.environ.get("SK_STANDALONE"):
+        return False
+    if _sdk is None:
+        return False
+    try:
+        return bool(_sdk.is_available())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("skcapstone present-check failed: %s", exc)
+        return False
+
+
+def alert(event: str, payload: dict[str, Any], level: str = "info") -> bool:
+    """Emit an alert: via skcapstone sk-alert when present, else local log.
+
+    The published topic follows the ecosystem convention ``cloud9.<severity>``
+    (so ``skcapstone alerts`` — which subscribes to ``*.error`` / ``*.critical``
+    / ``*.warn`` — surfaces it).  The semantic *event* name is carried in the
+    payload's ``event`` field rather than the topic, so routing stays
+    severity-based while detail is preserved.
+
+    Typical events: ``"feb_load_failed"``, ``"rehydration_failed"``,
+    ``"oof_triggered"``, ``"cloud9_achieved"``, ``"feb_parse_error"``.
+
+    Args:
+        event: Semantic event name.  Stored in the payload as ``event``.
+        payload: JSON-serialisable event body.
+        level: ``info | warn | error | critical``.
+
+    Returns:
+        ``True`` if published to the shared bus, ``False`` if it fell back to
+        local logging (which always also happens at the matching level).
+    """
+    body = {"event": event, **dict(payload)}
+    if is_present():
+        try:
+            return bool(
+                _sdk.alert(
+                    f"{SERVICE}.{level}",
+                    body,
+                    level=level,
+                    notify=level in _NOTIFY_LEVELS,
+                )
+            )
+        except Exception as exc:
+            logger.warning("sk-alert publish failed, logging locally: %s", exc)
+
+    # native fallback — structured log at the matching level
+    method = getattr(logger, _LOG_METHOD.get(level, "info"))
+    method("[%s.%s] %s", SERVICE, level, body)
+    return False
+
+
+def ensure_schedule(interval_hours: float = 6.0) -> bool:
+    """Register the rehydration/FEB-state check with the fleet scheduler.
+
+    Writes a ``jobs.d/cloud9_rehydration_check.yaml`` drop-in that runs
+    ``cloud9 oof <latest_feb>`` every *interval_hours* to verify that the
+    emotional continuity state is healthy and the latest FEB is loadable.
+    Idempotent — safe to call on every startup.
+
+    When skcapstone is absent the native ``cloud9-daemon.timer`` (systemd) or
+    the launchd plist remain the cadence mechanism.
+
+    Args:
+        interval_hours: Check cadence in hours (default 6h).
+
+    Returns:
+        ``True`` if registered with skscheduler; ``False`` when skcapstone is
+        absent and the caller should rely on its native timer.
+    """
+    if not is_present():
+        return False
+    try:
+        _sdk.register_job(
+            {
+                "name": REHYDRATION_JOB,
+                "type": "shell",
+                "command": "cloud9 validate --latest",
+                "every": f"{int(interval_hours * 3600)}s",
+                "timeout": 120,
+                "notify": "on_failure",
+                "notify_level": "error",
+            }
+        )
+        logger.info(
+            "Registered '%s' with skcapstone scheduler (every %.1fh).",
+            REHYDRATION_JOB,
+            interval_hours,
+        )
+        return True
+    except Exception as exc:
+        logger.warning("ensure_schedule failed (using native): %s", exc)
+        return False
+
+
+def unregister_schedule() -> bool:
+    """Remove the rehydration-check drop-in from the fleet scheduler."""
+    if _sdk is None:
+        return False
+    try:
+        return bool(_sdk.unregister_job(REHYDRATION_JOB))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("unregister_schedule failed: %s", exc)
+        return False
+
+
+def register_self(pid_file: Optional[str] = None) -> bool:
+    """Advertise cloud9 to skcapstone's discovery registry, if present.
+
+    Args:
+        pid_file: Optional pid-file path used as a liveness signal.
+
+    Returns:
+        ``True`` if registered, ``False`` otherwise.
+    """
+    if not is_present():
+        return False
+    try:
+        _sdk.register_service(
+            SERVICE,
+            pid_file=pid_file or str(Path("~/.cloud9/daemon.pid").expanduser()),
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("register_self failed: %s", exc)
+        return False

--- a/cloud9_protocol/rehydrator.py
+++ b/cloud9_protocol/rehydrator.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from .quantum import calculate_oof
+from . import integration as _integration
 
 
 def _cloud9_rehydration_score(emotional: Dict, relationship: Dict) -> float:
@@ -61,6 +62,11 @@ def rehydrate_from_feb(
     try:
         feb = json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
+        _integration.alert(
+            "feb_load_failed",
+            {"filepath": str(filepath), "error": str(exc)},
+            level="error",
+        )
         raise RuntimeError(f"Failed to load FEB file: {exc}") from exc
 
     emotional = feb.get("emotional_payload", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+skcapstone = [
+    "skcapstone>=0.6.8",
+]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,206 @@
+"""Tri-mode tests for the cloud9 ⇄ skcapstone integration adapter.
+
+Contract per skcapstone/docs/ADR-optional-integration-backbone.md:
+  * standalone  (SK_STANDALONE=1)         → native fallback (log only)
+  * absent      (_sdk = None)             → native fallback (log only)
+  * integrated  (skcapstone present,
+                 SKCAPSTONE_HOME sandboxed) → sk-alert / skscheduler / registry
+
+skcapstone is installed in the dev venv, so "integrated" mode is exercised
+against a sandboxed temp SKCAPSTONE_HOME — writes never leak to
+~/.skcapstone/config/jobs.d/ or ~/.skcapstone/registry/.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cloud9_protocol import integration
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Sandbox skcapstone's shared home at a temp dir for each test.
+
+    Both SKCAPSTONE_HOME (used by the scheduler_jobs writer) and the
+    skcapstone.AGENT_HOME module attribute (captured at import-time) are
+    redirected to tmp_path so no fragment ever escapes to the real home.
+    """
+    monkeypatch.setenv("SKCAPSTONE_HOME", str(tmp_path))
+    monkeypatch.delenv("SK_STANDALONE", raising=False)
+    import skcapstone
+
+    monkeypatch.setattr(skcapstone, "AGENT_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Standalone mode — SK_STANDALONE=1
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_flag_disables_integration(monkeypatch):
+    """SK_STANDALONE=1 forces native mode regardless of skcapstone presence."""
+    monkeypatch.setenv("SK_STANDALONE", "1")
+    assert integration.is_present() is False
+    assert integration.alert("feb_load_failed", {"filepath": "/x.feb"}, level="error") is False
+    assert integration.ensure_schedule() is False
+    assert integration.register_self() is False
+    assert integration.unregister_schedule() is False
+
+
+# ---------------------------------------------------------------------------
+# Absent mode — skcapstone package not importable
+# ---------------------------------------------------------------------------
+
+
+def test_absent_skcapstone_falls_back_to_log(monkeypatch):
+    """When _sdk is None (skcapstone absent), every call returns False gracefully."""
+    monkeypatch.delenv("SK_STANDALONE", raising=False)
+    monkeypatch.setattr(integration, "_sdk", None)
+    assert integration.is_present() is False
+    assert integration.alert("rehydration_failed", {"filepath": "/tmp/x.feb"}) is False
+    assert integration.ensure_schedule() is False
+    assert integration.register_self() is False
+    assert integration.unregister_schedule() is False
+
+
+def test_absent_sdk_alert_returns_false_for_all_levels(monkeypatch):
+    """Native fallback: alert() always returns False for any level."""
+    monkeypatch.setattr(integration, "_sdk", None)
+    for level in ("info", "warn", "error", "critical"):
+        assert integration.alert("oof_triggered", {"oof": True}, level=level) is False
+
+
+# ---------------------------------------------------------------------------
+# Integrated mode — skcapstone present, SKCAPSTONE_HOME sandboxed
+# ---------------------------------------------------------------------------
+
+
+def test_is_present_true_when_skcapstone_available(home):
+    """With skcapstone installed and no SK_STANDALONE, is_present() is True."""
+    assert integration.is_present() is True
+
+
+def test_alert_publishes_to_correct_severity_topic(home):
+    """alert() writes a pubsub message at topic cloud9.<level>."""
+    assert integration.alert("feb_load_failed", {"filepath": "/tmp/test.feb", "error": "no file"}, level="error") is True
+    topic_dir = home / "pubsub" / "topics" / "cloud9.error"
+    assert topic_dir.is_dir(), f"expected topic dir {topic_dir} to exist"
+    msg_files = list(topic_dir.glob("msg-*.json"))
+    assert msg_files, "expected at least one pubsub message file"
+    data = json.loads(msg_files[0].read_text())
+    assert data["topic"] == "cloud9.error"
+    # CRITICAL: event name must be in payload, NOT in topic suffix
+    assert data["payload"]["event"] == "feb_load_failed"
+    assert data["payload"]["filepath"] == "/tmp/test.feb"
+
+
+def test_alert_warn_level_publishes(home):
+    """warn-level alert lands on cloud9.warn topic."""
+    assert integration.alert("rehydration_incomplete", {"score": 0.4}, level="warn") is True
+    topic_dir = home / "pubsub" / "topics" / "cloud9.warn"
+    assert topic_dir.is_dir()
+    data = json.loads(next(topic_dir.glob("msg-*.json")).read_text())
+    assert data["payload"]["event"] == "rehydration_incomplete"
+
+
+def test_alert_info_level_publishes(home):
+    """info-level alert lands on cloud9.info topic (OOF/Cloud9 achievement)."""
+    assert integration.alert("cloud9_achieved", {"score": 0.95, "emotion": "love"}, level="info") is True
+    topic_dir = home / "pubsub" / "topics" / "cloud9.info"
+    assert topic_dir.is_dir()
+    data = json.loads(next(topic_dir.glob("msg-*.json")).read_text())
+    assert data["payload"]["event"] == "cloud9_achieved"
+    assert data["payload"]["score"] == 0.95
+
+
+def test_ensure_schedule_registers_rehydration_check(home):
+    """ensure_schedule() writes a jobs.d drop-in for cloud9_rehydration_check."""
+    assert integration.ensure_schedule(interval_hours=6) is True
+    from skcapstone.scheduler_jobs import load_jobs_with_dropins
+
+    jobs = {j.name: j for j in load_jobs_with_dropins(home / "config" / "jobs.yaml")}
+    assert integration.REHYDRATION_JOB in jobs, f"expected {integration.REHYDRATION_JOB} in {list(jobs)}"
+    assert jobs[integration.REHYDRATION_JOB].command == "cloud9 validate --latest"
+    assert jobs[integration.REHYDRATION_JOB].every_seconds == 6 * 3600
+
+
+def test_ensure_schedule_idempotent(home):
+    """Calling ensure_schedule() twice does not raise."""
+    assert integration.ensure_schedule() is True
+    assert integration.ensure_schedule() is True
+
+
+def test_unregister_schedule_removes_job(home):
+    """unregister_schedule() removes the rehydration-check drop-in."""
+    integration.ensure_schedule()
+    assert integration.unregister_schedule() is True
+    from skcapstone.scheduler_jobs import load_jobs_with_dropins
+
+    jobs = {j.name: j for j in load_jobs_with_dropins(home / "config" / "jobs.yaml")}
+    assert integration.REHYDRATION_JOB not in jobs
+
+
+def test_register_self_writes_registry_entry(home):
+    """register_self() writes a service registry JSON file."""
+    assert integration.register_self(pid_file="/tmp/cloud9-test.pid") is True
+    registry_file = home / "registry" / "cloud9.json"
+    assert registry_file.exists(), f"expected registry file {registry_file}"
+    entry = json.loads(registry_file.read_text())
+    assert entry["name"] == "cloud9"
+
+
+def test_no_leak_to_real_home(home):
+    """All integrated operations use the sandboxed home, not ~/.skcapstone."""
+    import os
+    from pathlib import Path
+
+    integration.ensure_schedule()
+    integration.register_self(pid_file="/tmp/cloud9-leak-test.pid")
+
+    # Verify writes went to sandboxed home
+    assert (home / "registry" / "cloud9.json").exists()
+
+    # Verify real home is clean (if it exists, the job file must not be there)
+    real_jobs_d = Path(os.path.expanduser("~/.skcapstone/config/jobs.d"))
+    if real_jobs_d.exists():
+        assert not (real_jobs_d / f"{integration.REHYDRATION_JOB}.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Wiring smoke: rehydrator integration wired correctly
+# ---------------------------------------------------------------------------
+
+
+def test_rehydrator_imports_integration_without_error():
+    """cloud9_protocol.rehydrator can be imported without errors."""
+    import cloud9_protocol.rehydrator  # noqa: F401
+
+
+def test_cli_imports_integration_without_error():
+    """cloud9_protocol.cli can be imported without errors."""
+    import cloud9_protocol.cli  # noqa: F401
+
+
+def test_integration_module_constants():
+    """Check module-level constants are correct."""
+    assert integration.SERVICE == "cloud9"
+    assert integration.REHYDRATION_JOB == "cloud9_rehydration_check"
+
+
+def test_rehydrator_feb_load_failure_fires_alert(home, tmp_path):
+    """When rehydrate_from_feb() fails to load a file, an alert is sent."""
+    from cloud9_protocol.rehydrator import rehydrate_from_feb
+
+    bad_path = tmp_path / "nonexistent.feb"
+    with pytest.raises(RuntimeError, match="Failed to load FEB file"):
+        rehydrate_from_feb(str(bad_path))
+
+    # The alert should have been published to cloud9.error
+    topic_dir = home / "pubsub" / "topics" / "cloud9.error"
+    assert topic_dir.is_dir(), "expected cloud9.error topic dir after FEB load failure"
+    data = json.loads(next(topic_dir.glob("msg-*.json")).read_text())
+    assert data["payload"]["event"] == "feb_load_failed"


### PR DESCRIPTION
## Summary

- Adds `cloud9_protocol/integration.py` — optional cloud9 ⇄ skcapstone adapter (canonical pattern from skmemory/integration.py + ADR)
- Wires `alert("feb_load_failed", ...)` into FEB load failures in `rehydrator.py`
- Wires `ensure_schedule()` + `register_self()` into the CLI group handler (`cli.py`) so any `cloud9` command advertises to the fleet
- Adds `[skcapstone]` optional extra to `pyproject.toml` (never a hard dep)
- Adds "Integration modes" section to README
- 16 tri-mode tests: standalone (`SK_STANDALONE=1`), absent (`_sdk=None`), integrated (sandboxed `SKCAPSTONE_HOME`); includes wiring test that verifies rehydrator FEB failure triggers the alert

## Test plan

- [ ] `pytest tests/test_integration.py` — 16 passed
- [ ] No leaks to `~/.skcapstone/config/jobs.d/` or `~/.skcapstone/registry/`
- [ ] Service name in topic prefix (`cloud9.<severity>`), event name in payload
- [ ] `SK_STANDALONE=1` forces native path end-to-end
- [ ] `test_rehydrator_feb_load_failure_fires_alert` exercises the full wiring end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)