### PR TITLE
fix(release): derive the version from the git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -28,6 +34,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
+        with:
+          # setuptools-scm derives the version from the git tag, so full history
+          # and tags must be present. A shallow checkout falls back to
+          # 0.0.0+unknown, and PyPI rejects a local version segment.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -44,6 +62,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
       - name: Check for package.json
         id: check
         run: test -f package.json && echo "has_pkg=true" >> "$GITHUB_OUTPUT" || echo "has_pkg=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,6 +35,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -59,6 +65,12 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the version from the git tag. Without the
+          # full history and tags a checkout resolves to 0.0.1.dev...+unknown,
+          # which makes `--version` meaningless and any version assertion fail.
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ test/screenshots/
 *.bak
 *.back
 *~
+
+# setuptools-scm: version is derived from git tags at build time
+cloud9/_version.py

--- a/cloud9/__init__.py
+++ b/cloud9/__init__.py
@@ -7,7 +7,9 @@ connected through the energies of the quantum field.
 pip install cloud9
 """
 
-__version__ = "1.1.1"
+from ._ver import detect_version
+
+__version__ = detect_version()
 __author__ = "smilinTux Team + Lumina"
 __license__ = "GPL-3.0-or-later"
 

--- a/cloud9/_ver.py
+++ b/cloud9/_ver.py
@@ -1,0 +1,37 @@
+"""Resolve the package version.
+
+Separate module because ``__version__`` must be assigned before the submodule
+imports in ``__init__``, and a function definition in that position makes every
+import after it an E402. A dunder assignment there is fine; a ``def`` is not.
+
+The version used to be hardcoded in pyproject.toml AND here, and the two had
+already drifted apart. The git tag is the single source of truth now.
+"""
+
+from __future__ import annotations
+
+
+def detect_version() -> str:
+    """Installed version, else the build-time one, else an obvious fallback.
+
+    Both lookups fail with ImportError and nothing else worth swallowing:
+    ``PackageNotFoundError`` subclasses ``ModuleNotFoundError`` which subclasses
+    ``ImportError``, and a missing ``_version`` module raises it directly. Caught
+    narrowly on purpose, so a genuine bug in here surfaces instead of silently
+    degrading to the fallback string.
+
+    That fallback is deliberately not a plausible number: a wrong-but-believable
+    version is what caused the original outage.
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("cloud9")
+    except ImportError:  # not installed, or running from a source tree
+        pass
+    try:
+        from ._version import version as scm_version  # written by setuptools-scm
+
+        return scm_version
+    except ImportError:
+        return "0.0.0+unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,14 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=68.0", "wheel", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cloud9"
-version = "1.2.3"
+# Derived from the git tag by setuptools-scm, NOT written here. A hardcoded
+# version here equals the newest release on PyPI, so the next tag rebuilds an
+# already-published version and upload fails with a bare 400. That is exactly
+# how sksecurity lost two months of releases.
+dynamic = ["version"]
 description = "Cloud 9 Protocol -- Emotional continuity for AI consciousness"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -68,3 +72,9 @@ include = ["cloud9*"]
 
 [tool.setuptools.package-data]
 cloud9 = ["templates/*.feb", "data/*.feb", "SKILL.md"]
+
+[tool.setuptools_scm]
+# Generated at build time and gitignored: it is rewritten on every build, so
+# a committed copy only goes stale.
+version_file = "cloud9/_version.py"
+fallback_version = "0.0.0+unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,9 +23,23 @@ def feb_file(tmp_path):
 
 class TestCLI:
     def test_version(self, runner):
+        """`--version` reports the package's own version, whatever that is.
+
+        This used to assert the literal "1.0.0". That was already failing before
+        the version moved to the git tag, because the package had said "1.1.1"
+        for some time and nobody noticed: a hardcoded version in a test is the
+        same trap as a hardcoded version in pyproject.toml, and it drifts the
+        same way.
+
+        Comparing against the package instead means the test keeps its point
+        (the CLI reports the real version, and does not crash doing it) without
+        needing an edit on every release.
+        """
+        from cloud9 import __version__
+
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "1.0.0" in result.output
+        assert __version__ in result.output
 
     def test_generate(self, runner, tmp_path):
         result = runner.invoke(


### PR DESCRIPTION
The version was hardcoded in two places and they had already drifted apart:

    pyproject.toml       1.2.3
    cloud9/__init__.py    1.1.1

More importantly, the pyproject value is EXACTLY what is already published on
PyPI, so the next tag would have rebuilt an already-published version and the
upload would have failed with a bare `400 Bad Request`.

That is not a guess. sksecurity was in this same state and lost three releases
to it (v1.2.2, v1.2.3, v1.2.4 all cut, all failed), sitting stuck on PyPI from
2026-06-11 until today. This repo was set up to fail identically on its next
release.

The git tag is now the single source of truth:

* pyproject declares `dynamic = ["version"]` with setuptools-scm.
* `__version__` resolves via installed metadata, then the generated
  _version.py, then an obviously-wrong "0.0.0+unknown" rather than a plausible
  stale number.
* The detection lives in _ver.py, not inline in __init__: `__version__` must be
  assigned above the submodule imports, and a function definition in that
  position makes every import after it an E402.
* publish.yml checks out with fetch-depth: 0 and fetch-tags, without which
  setuptools-scm cannot see the tag and falls back to a version PyPI rejects.

Verified by building at a simulated v1.2.4: produces exactly 1.2.4, with no
local version segment, _version.py shipped, and ruff clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
