### PR TITLE
fix(ci): remove the duplicate `with:` that made publish.yml unloadable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,12 +40,6 @@ jobs:
           # which makes `--version` meaningless and any version assertion fail.
           fetch-depth: 0
           fetch-tags: true
-        with:
-          # setuptools-scm derives the version from the git tag, so full history
-          # and tags must be present. A shallow checkout falls back to
-          # 0.0.0+unknown, and PyPI rejects a local version segment.
-          fetch-depth: 0
-          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
The publish workflow has been failing in 0s with "This run likely failed because
of a workflow file issue" since the version-from-tag change, so the v1.2.4 /
v0.1.8 tags built nothing and no release reached PyPI.

Cause: the patch that added `fetch-depth: 0` / `fetch-tags: true` to every
checkout guarded against a pre-existing `with:` by inspecting the text after
`s.index(line)`. `str.index` returns the FIRST match, and every checkout step
is the identical line `- uses: actions/checkout@v4`, so the guard kept reading
the first step and added a second `with:` to a step that already had one.
GitHub rejects a duplicate mapping key outright.

The check that let it through is the more useful lesson: `yaml.safe_load`
accepted these files happily, because PyYAML silently keeps the LAST duplicate
key instead of erroring. Reading `step["with"]` back showed exactly one block,
so the verification confirmed the wrong thing. Duplicate keys can only be caught
by a loader that treats them as fatal.

Every workflow in this repo has now been re-checked with such a loader, and each
checkout asserted to carry exactly one `with:` with both fetch settings.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
