### PR TITLE
ci: real secret scanning via the gitleaks binary

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,46 @@
+name: secret-scan
+
+# Fleet secret-scan gate: runs the gitleaks BINARY, not gitleaks-action.
+#
+# The action requires a paid license for ORGANIZATION-owned repos, and smilinTux
+# is an org, so it exits with "missing gitleaks license" BEFORE scanning a single
+# byte. skcomms carried exactly that gate for months: permanently red, therefore
+# ignored, and scanning nothing at all. gitleaks itself is MIT and free; only the
+# wrapper is licensed, so calling the binary restores real scanning at no cost
+# with no org secret to provision.
+#
+# Pinned to an exact version so a new upstream rule cannot redden CI without a
+# deliberate bump. --redact keeps a genuine finding out of public CI logs.
+# --exit-code 1 fails the build on a finding.
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # the scan walks commits, not just the tree
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.28.0
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      # This repo's history scanned CLEAN on 2026-08-14, so the gate covers the
+      # FULL history. If it ever goes red, a secret was ADDED: rotate it and
+      # purge it, do not weaken this to an incremental scan.
+      - name: Scan (full history)
+        run: |
+          set -euo pipefail
+          CFG=""
+          [ -f .gitleaks.toml ] && CFG="--config .gitleaks.toml"
+          gitleaks detect --source . $CFG --redact --no-banner --exit-code 1


### PR DESCRIPTION
## Why

`gitleaks-action` requires a **paid license for organization-owned repos**. smilinTux is an org, so it exits with `missing gitleaks license` **before scanning a single byte**.

skcomms carried exactly that gate for months: permanently red, therefore ignored, and scanning nothing. That is worse than no gate at all.

gitleaks itself is **MIT and free**; only the action wrapper is licensed. Calling the binary restores real scanning at no cost, with no org secret to provision.

## Scope here: **full history**

This repo's history scanned clean on 2026-08-14, so the gate covers every commit. If it ever goes red, a secret was *added*: rotate and purge it rather than weakening the scan.

## Details

- Pinned to gitleaks **8.28.0**, so a new upstream rule cannot redden CI without a deliberate bump.
- `--redact`, so a genuine finding never echoes a secret into public CI logs.
- `--exit-code 1`, so a finding fails the build.
- Uses the repo's `.gitleaks.toml` allowlist when present.

## Verified

The approach was checked in both directions on skcomms before rolling out, because a gate that passes everything is no better than one that never ran:

| scenario | result |
|---|---|
| clean tree | `no leaks found`, exit 0 |
| planted secret | `leaks found: 2`, exit 1 |

Part of a fleet-wide rollout to 29 repos.