### PR TITLE
fix(tests): retarget the renamed quantum CLI group + stop the suite writing to the real fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --tb=short
-      - run: pip install black ruff && black --check cloud9/ tests/ && ruff check cloud9/
+      # No `pip install black ruff` here: that pulled the LATEST ruff on every
+      # run, ignoring the bounded versions in the dev extra installed above, so
+      # ruff 0.16's wider defaults turned this gate red with no code change.
+      - run: black --check cloud9/ tests/ && ruff check cloud9/
         if: matrix.python-version == '3.12'

--- a/cloud9/integration.py
+++ b/cloud9/integration.py
@@ -161,7 +161,10 @@ def ensure_schedule(interval_hours: float = 6.0) -> bool:
 
 def unregister_schedule() -> bool:
     """Remove the rehydration-check drop-in from the fleet scheduler."""
-    if _sdk is None:
+    # is_present(), not `_sdk is None`: the documented contract is that
+    # SK_STANDALONE=1 forces native mode regardless of skcapstone presence,
+    # and every sibling function here gates on is_present().
+    if not is_present():
         return False
     try:
         return bool(_sdk.unregister_job(REHYDRATION_JOB))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,12 @@ pqc = [
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
-    "black>=23.0",
-    "ruff>=0.1",
+    # Bounded for the same reason as ruff: black's stable style changes with
+    # the calendar year, so an unbounded floor reformats the tree on its own.
+    "black>=23.0,<27.0",
+    # Bounded: an unbounded `ruff>=0.1` let a minor release change the default
+    # rule set under CI and turn a green gate red with no code change.
+    "ruff>=0.15,<0.17",
 ]
 
 [project.urls]
@@ -62,6 +66,21 @@ Issues = "https://github.com/smilinTux/cloud9-python/issues"
 
 [project.scripts]
 cloud9 = "cloud9.cli:main"
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+# Selected EXPLICITLY. With no config, `ruff check` uses ruff's own default
+# rule set, which is not stable across releases: the CI step ran a bare
+# `pip install black ruff`, so it picked up 0.16, whose defaults added UP and
+# BLE, and the gate went from green to 213 errors with no change to this repo.
+#
+# This is the set cloud9 has actually been enforcing (ruff's pre-0.16 default),
+# now written down so it cannot drift again. Widening to UP/BLE/SIM/RUF is
+# worth doing, but it is a real refactor (213 findings, mostly Dict->dict and
+# Optional[X]->X | None) and belongs in its own change, not here.
+select = ["E4", "E7", "E9", "F"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared test fixtures for cloud9.
+
+The important one is `_sandbox_fleet`, which keeps the suite from writing into
+the developer's real ~/.skcapstone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_fleet(tmp_path, monkeypatch):
+    """Force standalone mode and a throwaway skcapstone home for every test.
+
+    `cloud9.cli.main` is a click group whose callback calls
+    `integration.ensure_schedule()` and `integration.register_self()` on ANY
+    CLI invocation. On a machine where skcapstone is actually installed (every
+    sovereign node) that meant each CliRunner test registered a REAL fleet job
+    in ~/.skcapstone/config/jobs.d/ and a real registry entry. Running the
+    suite locally silently added `cloud9_rehydration_check` to the live
+    scheduler at nodes=all.
+
+    SK_STANDALONE=1 makes `integration.is_present()` return False, so the
+    adapter takes its native no-op path. SKCAPSTONE_HOME is redirected as well
+    so that anything bypassing the flag still cannot reach the real home.
+
+    Integrated-mode tests opt back in via the `home` fixture in
+    test_integration.py, which deletes SK_STANDALONE and points
+    SKCAPSTONE_HOME at its own tmp_path.
+    """
+    monkeypatch.setenv("SK_STANDALONE", "1")
+    monkeypatch.setenv("SKCAPSTONE_HOME", str(tmp_path / "skcapstone-home"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,18 +95,27 @@ class TestCLI:
         assert result.exit_code == 0
         assert "Love loaded" in result.output
 
-    def test_quantum_score(self, runner):
+    # The `quantum` command group was renamed to `resonance`; the underlying
+    # cloud9/quantum.py module kept its name. These tests still invoked
+    # `quantum` and so only ever proved click's "No such command" exit code 2.
+    def test_resonance_score(self, runner):
         result = runner.invoke(
             main,
-            ["quantum", "score", "-i", "0.95", "-t", "0.97", "-d", "9", "-v", "0.92"],
+            ["resonance", "score", "-i", "0.95", "-t", "0.97", "-d", "9", "-v", "0.92"],
         )
         assert result.exit_code == 0
         assert "Cloud 9 Score" in result.output
 
-    def test_quantum_coherence(self, runner, feb_file):
-        result = runner.invoke(main, ["quantum", "coherence", feb_file])
+    def test_resonance_coherence(self, runner, feb_file):
+        result = runner.invoke(main, ["resonance", "coherence", feb_file])
         assert result.exit_code == 0
         assert "Coherence" in result.output
+
+    def test_quantum_group_is_gone(self, runner):
+        """Guard the rename: `quantum` must not silently come back as a group."""
+        result = runner.invoke(main, ["quantum", "score"])
+        assert result.exit_code == 2
+        assert "No such command" in result.output
 
     def test_seed_plant(self, runner, tmp_path):
         result = runner.invoke(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,7 +30,12 @@ def home(tmp_path, monkeypatch):
     """
     monkeypatch.setenv("SKCAPSTONE_HOME", str(tmp_path))
     monkeypatch.delenv("SK_STANDALONE", raising=False)
-    import skcapstone
+    # skcapstone is a sovereign sibling package and is NOT published to PyPI,
+    # so it cannot be installed on a public runner. Skip integrated-mode tests
+    # there rather than erroring out; standalone and absent mode still run.
+    skcapstone = pytest.importorskip(
+        "skcapstone", reason="integrated mode needs skcapstone (not on PyPI)"
+    )
 
     monkeypatch.setattr(skcapstone, "AGENT_HOME", str(tmp_path))
     return tmp_path


### PR DESCRIPTION
Closes ITIL `inc-efab849b` (SEV4).

## The two failing tests

`test_quantum_score` and `test_quantum_coherence` invoked `["quantum", ...]`. cloud9 has no `quantum` command, so click returned exit code 2 and both failed on `assert result.exit_code == 0`.

**Correcting the diagnosis:** the feature was neither dropped nor unimplemented. The `quantum` command **group was renamed to `resonance`** while the module behind it kept the name `cloud9/quantum.py`:

```python
@main.group()
def resonance() -> None: ...

@resonance.command()
def score(...): from .quantum import calculate_cloud9_score, calculate_oof

@resonance.command()
def coherence(...): from .quantum import measure_coherence
```

Both subcommands still exist and still call the same functions, so the tests are **retargeted rather than deleted** and the coverage is real again. Added `test_quantum_group_is_gone` so the rename cannot silently reverse.

## Three problems those two were masking

### 1. `SK_STANDALONE=1` was not honoured (real bug)

`integration.unregister_schedule()` gated on `_sdk is None` while every sibling function gates on `is_present()`. With skcapstone installed it called into the SDK anyway, contradicting the documented contract:

> standalone (SK_STANDALONE=1) → native fallback (log only)

Public CI cannot catch this, because skcapstone is never installed there. It only fails on a sovereign node, which is exactly where it matters.

### 2. The test suite registered REAL fleet jobs 🔴

`cloud9.cli.main` is a click group whose callback runs `ensure_schedule()` + `register_self()` on **any** invocation, and there was no `conftest.py` sandboxing it. So every `CliRunner` test wrote to the developer's real home:

- `~/.skcapstone/config/jobs.d/cloud9_rehydration_check.yaml`
- `~/.skcapstone/registry/cloud9.json`

Running the suite on this box wrote both files and they showed up in `skcapstone scheduler list` at `nodes=all`.

To be precise about what is and is not proven: `cloud9_rehydration_check` **is** documented fleet infrastructure (`docs/ARCHITECTURE.md`), so the suite was rewriting a job that is meant to exist rather than inventing one. What is demonstrated is that **the test suite writes to the developer's real `~/.skcapstone`** — traced per-test to `test_generate`, which creates the file when it is absent. Whether a given registration originated from a test run or from the real daemon cannot be told apart afterwards, and that is exactly the problem. Tests should not be able to touch live fleet config at all.

New `tests/conftest.py` forces `SK_STANDALONE=1` and a throwaway `SKCAPSTONE_HOME` for every test; the integrated-mode `home` fixture opts back in exactly as before. `test_no_leak_to_real_home` now means something: it was passing only because the leak happened in a *different* file's tests.

### 3. 10 collection errors in the CI workflow

`test_integration.py`'s `home` fixture hard-imported `skcapstone`, which is not published to PyPI and so cannot exist on a public runner:

```
ERROR tests/test_integration.py::... - ModuleNotFoundError: No module named 'skcapstone'
```

Now `pytest.importorskip`, so integrated mode skips honestly there and still runs on a sovereign node.

## Verification

Both environments, since the two behave differently and each hides bugs from the other:

| environment | before | after |
|---|---|---|
| clean venv, no skcapstone (mirrors CI) | 2 failed, 10 errors | **211 passed, 21 skipped** |
| this box, skcapstone present | 3 failed | **232 passed** |

Confirmed no file appears under the real `~/.skcapstone` after a full run (instrumented per-test, which is how the leak was traced to `test_generate`). `black --check cloud9/ tests/` and `ruff check cloud9/` both clean.


---

## Added after the first CI run: the lint gate was drifting too

The first push came back red on `test (3.12)` (the only job that runs lint) with **213 ruff errors**. Verified identical on `origin/main`, so it is pre-existing and not from this PR.

Same root cause as the skseed incident: the step ran `pip install black ruff` **unpinned** on every run, ignoring the bounded versions installed a step earlier, so it picked up ruff 0.16 whose defaults added UP/BLE/SIM/RUF.

- `[tool.ruff.lint]` now declares the set cloud9 has actually been enforcing (`E4/E7/E9/F`)
- the lint step uses the already-installed tools instead of reinstalling latest
- ruff and black are both bounded in the dev extra

Verified version-independent: ruff 0.15.4 and 0.16.3 both report clean, where before they reported 0 and 213.

Widening to UP/BLE/SIM/RUF is worth doing (mostly `Dict`→`dict` and `Optional[X]`→`X | None`) but that is a real refactor and deserves its own change.

**Final CI: all 7 jobs green.**