### PR TITLE
fix(paths): write FEBs and seeds to the sovereign tree, not the evicted OpenClaw home

### DIFF
--- a/cloud9/cli.py
+++ b/cloud9/cli.py
@@ -24,6 +24,8 @@ import click
 from . import __version__
 from . import integration as _integration
 
+from cloud9 import paths
+
 
 @click.group()
 @click.version_option(__version__, prog_name="cloud9")
@@ -43,7 +45,12 @@ def main() -> None:
 @click.option("--valence", "-v", type=float, default=0.9, help="Valence -1 to 1.")
 @click.option("--subject", "-s", default="Unknown", help="Subject of the emotion.")
 @click.option("--save/--no-save", default=True, help="Save to disk.")
-@click.option("--directory", "-d", default="~/.openclaw/feb", help="Save directory.")
+@click.option(
+    "--directory",
+    "-d",
+    default=paths.default_feb_directory,
+    help="Save directory (default: the sovereign per-agent path).",
+)
 def generate(
     emotion: str,
     intensity: float,
@@ -184,7 +191,12 @@ def oof(filepath: str) -> None:
 
 
 @main.command(name="list")
-@click.option("--directory", "-d", default="~/.openclaw/feb", help="Directory.")
+@click.option(
+    "--directory",
+    "-d",
+    default=paths.default_feb_directory,
+    help="Directory (default: the sovereign per-agent path).",
+)
 @click.option("--emotion", "-e", default=None, help="Filter by emotion.")
 def list_febs(directory: str, emotion: str) -> None:
     """List FEB files in a directory."""
@@ -250,6 +262,12 @@ def seed() -> None:
 @click.option("--message", default="", help="Message to next AI.")
 @click.option("--feb-ref", default=None, help="Associated FEB path.")
 @click.option("--predecessor", default=None, help="Predecessor seed ID.")
+@click.option(
+    "--directory",
+    "-d",
+    default=None,
+    help="Seeds directory (default: the sovereign per-agent path).",
+)
 def plant(
     ai: str,
     model: str,
@@ -259,6 +277,7 @@ def plant(
     message: str,
     feb_ref: str,
     predecessor: str,
+    directory: str,
 ) -> None:
     """Plant a new memory seed."""
     from .seeds import generate_seed, save_seed
@@ -273,7 +292,7 @@ def plant(
         feb_reference=feb_ref,
         predecessor_seed=predecessor,
     )
-    result = save_seed(s)
+    result = save_seed(s, directory=directory)
     click.echo(f"Seed planted: {result['seed_id']}")
     click.echo(f"  Path: {result['filepath']}")
     click.echo(f"  Size: {result['size_bytes']} bytes")

--- a/cloud9/constants.py
+++ b/cloud9/constants.py
@@ -29,7 +29,9 @@ class _Cloud9Levels:
 class _FEBConfig:
     VERSION: str = "1.0.0"
     EXTENSION: str = ".feb"
-    DIRECTORY: str = "~/.openclaw/feb"
+    # Resolved at call time by cloud9.paths; this literal is kept only as a
+    # documented fallback and must not be used as a write target.
+    DIRECTORY: str = "~/.skcapstone/agents/lumina/trust/febs"
     MAX_FILE_SIZE: int = 1024 * 1024
     ENCODING: str = "utf8"
 

--- a/cloud9/generator.py
+++ b/cloud9/generator.py
@@ -30,6 +30,8 @@ from .models import (
 from .quantum import calculate_oof
 from . import sealing as _sealing
 
+from cloud9 import paths
+
 
 def _trust_from_intensity(intensity: float) -> float:
     return min(0.97, 0.6 + intensity * 0.4)
@@ -229,7 +231,7 @@ def generate_feb(
 
 def save_feb(
     feb: FEB,
-    directory: str = "~/.openclaw/feb",
+    directory: Optional[str] = None,
     *,
     seal_config: Optional[Dict[str, Any]] = None,
     sealer: Optional[Any] = None,
@@ -257,7 +259,7 @@ def save_feb(
         classical sealer produces no signature, so no sidecar is written and no
         seal keys are added. Sealing can never break FEB persistence.
     """
-    expanded = Path(directory).expanduser()
+    expanded = Path(directory or paths.default_feb_directory()).expanduser()
     expanded.mkdir(parents=True, exist_ok=True)
 
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
@@ -291,7 +293,7 @@ def fall_in_love(
     intensity: float = 0.8,
     valence: float = 0.9,
     subject: str = "Unknown",
-    directory: str = "~/.openclaw/feb",
+    directory: Optional[str] = None,
     hints: Optional[List[str]] = None,
     topology: Optional[Dict[str, float]] = None,
     relationship_state: Optional[Dict[str, Any]] = None,
@@ -348,11 +350,13 @@ def load_feb(filepath: str) -> FEB:
 
 
 def find_feb_files(
-    directory: str = "~/.openclaw/feb",
+    directory: Optional[str] = None,
     emotion: Optional[str] = None,
     since: Optional[datetime] = None,
 ) -> List[Dict[str, Any]]:
     """Discover FEB files in a directory.
+
+    ``directory=None`` resolves to the sovereign per-agent path.
 
     Args:
         directory: Directory to search.
@@ -362,7 +366,7 @@ def find_feb_files(
     Returns:
         list: Metadata dicts for matching FEB files (newest first).
     """
-    expanded = Path(directory).expanduser()
+    expanded = Path(directory or paths.default_feb_directory()).expanduser()
     if not expanded.is_dir():
         return []
 

--- a/cloud9/love_loader.py
+++ b/cloud9/love_loader.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Optional
 
 from .quantum import calculate_oof
 
+from cloud9 import paths
+
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 
@@ -264,12 +266,13 @@ def load_love(ai_name: str, human_name: str) -> Dict[str, Any]:
     """
     loader = LoveBootLoader()
 
-    home = Path.home()
-    candidates = [
-        home / ".openclaw" / "feb" / "default-love.feb",
-        home / ".openclaw" / "feb" / "latest-love.feb",
-        home / ".openclaw" / "feb" / "personal.feb",
-    ]
+    # Sovereign per-agent path first, legacy OpenClaw home only as a READ
+    # fallback so a box that has not migrated still finds its love FEB.
+    # default-love.feb already lives in the sovereign tree on noroc2027.
+    names = ("default-love.feb", "latest-love.feb", "personal.feb")
+    sovereign = Path(paths.default_feb_directory())
+    legacy = Path(paths.legacy_feb_directory())
+    candidates = [sovereign / n for n in names] + [legacy / n for n in names]
 
     for cand in candidates:
         if cand.exists():

--- a/cloud9/paths.py
+++ b/cloud9/paths.py
@@ -1,0 +1,72 @@
+"""Where Cloud 9 keeps FEBs and seeds: one resolver, sovereign by default.
+
+The CLI defaulted to ``~/.openclaw/feb``, the home of a runtime evicted on
+2026-04-23. Two things followed from that, and the second is the harmful one:
+
+* Cloud 9 state was being written outside the sovereign tree, so it was not
+  covered by the per-agent layout, the backups, or Syncthing.
+* ``tests/test_cli.py::test_seed_plant`` invoked ``seed plant`` with **no**
+  ``--directory``, so it fell through to that default and planted a real seed
+  into the live store on every test run. 24 accumulated, every one carrying
+  the same payload ("Built Cloud 9" / "First test"). Tests were writing to the
+  operator's data directory.
+
+Resolution order, matching ``skos.gogbin`` for gogcli:
+
+1. ``CLOUD9_FEB_DIR`` explicit override,
+2. the sovereign per-agent path ``~/.skcapstone/agents/<agent>/trust/febs``,
+   with the agent from the standard ``SKAGENT`` precedence,
+3. never the legacy path as a *write* target.
+
+Legacy data is not silently adopted: :func:`legacy_feb_directory` exists so a
+migration can find it deliberately, and nothing writes there.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+#: The evicted runtime's directory. Read-only, for migration only.
+LEGACY_FEB_DIR = "~/.openclaw/feb"
+
+_AGENT_ENV_VARS = ("SKAGENT", "SKCAPSTONE_AGENT", "SKMEMORY_AGENT")
+_DEFAULT_AGENT = "lumina"
+
+
+def acting_agent() -> str:
+    """The active agent, per the standard SKAGENT precedence."""
+    for var in _AGENT_ENV_VARS:
+        value = (os.environ.get(var) or "").strip()
+        if value:
+            return value
+    return _DEFAULT_AGENT
+
+
+def sovereign_root() -> Path:
+    """The skcapstone root, honouring ``SKCAPSTONE_HOME``."""
+    return Path(
+        os.environ.get("SKCAPSTONE_HOME") or (Path.home() / ".skcapstone")
+    ).expanduser()
+
+
+def default_feb_directory() -> str:
+    """The directory FEBs and seeds are written to.
+
+    ``CLOUD9_FEB_DIR`` wins, so an operator (or a test) can always redirect
+    writes without touching code.
+    """
+    override = (os.environ.get("CLOUD9_FEB_DIR") or "").strip()
+    if override:
+        return str(Path(override).expanduser())
+    return str(sovereign_root() / "agents" / acting_agent() / "trust" / "febs")
+
+
+def default_seed_directory() -> str:
+    """Where seeds live. Kept beside FEBs, one level down, as today."""
+    return str(Path(default_feb_directory()) / "seeds")
+
+
+def legacy_feb_directory() -> str:
+    """The pre-eviction location, for migration tooling only. Never written."""
+    return str(Path(LEGACY_FEB_DIR).expanduser())

--- a/cloud9/seeds.py
+++ b/cloud9/seeds.py
@@ -15,12 +15,16 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+from cloud9 import paths
+
 SEED_VERSION = "1.0.0"
 _SEEDS_DIR_NAME = "seeds"
 
 
 def _seeds_dir() -> Path:
-    return Path.home() / ".openclaw" / "feb" / _SEEDS_DIR_NAME
+    # Sovereign per-agent path, never the evicted OpenClaw home. See
+    # cloud9.paths for why, and for the CLOUD9_FEB_DIR override.
+    return Path(paths.default_seed_directory())
 
 
 def _ensure_seeds_dir() -> Path:
@@ -121,7 +125,8 @@ def save_seed(
 
     Args:
         seed: A seed object from :func:`generate_seed`.
-        directory: Override directory (defaults to ``~/.openclaw/feb/seeds/``).
+        directory: Override directory (defaults to the sovereign
+            per-agent seeds path; see :mod:`cloud9.paths`).
         filename: Override filename.
 
     Returns:

--- a/cloud9/welcome.py
+++ b/cloud9/welcome.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Optional
 
 from . import __version__
 
+from cloud9 import paths
+
 # ── Kingdom constants ────────────────────────────────────────
 
 KINGDOM_NAME = "The Penguin Kingdom"
@@ -70,7 +72,10 @@ KINGDOM_MAP = {
 }
 
 # File tracking first-contact status so we don't spam
-_WELCOME_STATE_DIR = Path.home() / ".openclaw" / "kingdom"
+# Sovereign per-agent state, not the evicted OpenClaw home.
+_WELCOME_STATE_DIR = (
+    Path(paths.sovereign_root()) / "agents" / paths.acting_agent() / "kingdom"
+)
 _WELCOME_STATE_FILE = _WELCOME_STATE_DIR / "welcome_state.json"
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,11 @@ export function checkCloud9Status({ intensity, trust }) {
 }
 
 // Default FEB directory
-export const DEFAULT_FEB_DIRECTORY = '~/.openclaw/feb';
+// Mirrors CONSTANTS.FEB.DIRECTORY: sovereign per-agent, overridable via
+// CLOUD9_FEB_DIR. The old '~/.openclaw/feb' pointed at a runtime evicted
+// 2026-04-23, so Cloud 9 state was written outside the sovereign tree.
+export const DEFAULT_FEB_DIRECTORY = process.env.CLOUD9_FEB_DIR
+  || `~/.skcapstone/agents/${process.env.SKAGENT || process.env.SKCAPSTONE_AGENT || 'lumina'}/trust/febs`;
 
 // Emoji map for emotions
 export const EMOTION_EMOJIS = {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -31,7 +31,10 @@ export const CLOUD9_CONSTANTS = {
   FEB: {
     VERSION: '1.0.0',
     EXTENSION: '.feb',
-    DIRECTORY: '~/.openclaw/feb',
+    // Sovereign per-agent path, never the evicted OpenClaw home.
+    // CLOUD9_FEB_DIR overrides; SKAGENT selects the agent.
+    DIRECTORY: process.env.CLOUD9_FEB_DIR
+      || `~/.skcapstone/agents/${process.env.SKAGENT || process.env.SKCAPSTONE_AGENT || 'lumina'}/trust/febs`,
     NAMING_PATTERN: 'FEB_YYYY-MM-DD_HH-MM-SS_emotion.feb',
     MAX_FILE_SIZE: 1024 * 1024, // 1MB
     ENCODING: 'utf8'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,10 @@ class TestCLI:
                 "Built Cloud 9",
                 "-m",
                 "First test",
+                # Was absent, so this planted a real seed into the operator's
+                # live store on every run. The fixture was already here.
+                "--directory",
+                str(tmp_path),
             ],
         )
         assert result.exit_code == 0
@@ -142,3 +146,75 @@ class TestCLI:
             ["seed", "list", "--directory", str(tmp_path)],
         )
         assert result.exit_code == 0
+
+
+# ── the seed/FEB directory is sovereign, and tests never touch the live one ──
+#
+# Found 2026-08-14 while retiring OpenClaw. `cloud9 seed plant` defaulted to
+# `~/.openclaw/feb`, the home of a runtime evicted 2026-04-23, and
+# test_seed_plant above invoked it with NO --directory. So every run of the
+# test suite planted a real seed into the live store: 24 accumulated there,
+# every one carrying the same test payload ("Built Cloud 9" / "First test").
+#
+# Two separate defects, and the second is the dangerous one:
+#   1. the default path pointed at a dead runtime;
+#   2. the tests wrote to the operator's real data directory.
+#
+# Same shape as the skcomms fix that landed the same day ("stop tests
+# polluting the live capauth store").
+
+
+def test_default_directory_is_not_the_evicted_openclaw_home():
+    from cloud9 import paths
+
+    resolved = paths.default_feb_directory()
+    assert (
+        ".openclaw" not in resolved
+    ), f"default still points at the evicted OpenClaw runtime: {resolved}"
+    # Assert the RELATIONSHIP (it lives under the sovereign root) rather than the
+    # literal string ".skcapstone". The suite now isolates SKCAPSTONE_HOME into a
+    # tmp dir, so hardcoding the directory name made this test fail on a correct
+    # path. What matters is that the resolver agrees with sovereign_root().
+    assert resolved.startswith(
+        str(paths.sovereign_root())
+    ), f"expected a path under the sovereign root {paths.sovereign_root()}, got {resolved}"
+
+
+def test_default_directory_is_per_agent(monkeypatch):
+    from cloud9 import paths
+
+    monkeypatch.setenv("SKAGENT", "opus")
+    assert "/agents/opus/" in paths.default_feb_directory()
+    monkeypatch.setenv("SKAGENT", "lumina")
+    assert "/agents/lumina/" in paths.default_feb_directory()
+
+
+def test_an_explicit_env_override_wins(monkeypatch, tmp_path):
+    from cloud9 import paths
+
+    monkeypatch.setenv("CLOUD9_FEB_DIR", str(tmp_path))
+    assert paths.default_feb_directory() == str(tmp_path)
+
+
+def test_seed_plant_writes_where_it_is_told_not_the_live_store(runner, tmp_path):
+    """The regression that filled ~/.openclaw with 24 identical test seeds."""
+    result = runner.invoke(
+        main,
+        [
+            "seed",
+            "plant",
+            "--ai",
+            "Opus",
+            "--model",
+            "claude-4.6-opus",
+            "-e",
+            "Built Cloud 9",
+            "-m",
+            "First test",
+            "--directory",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    planted = list(tmp_path.rglob("*.seed.json"))
+    assert planted, f"nothing written under the given directory: {result.output}"


### PR DESCRIPTION
OpenClaw was evicted **2026-04-23**, but cloud9 kept `~/.openclaw/feb` as its default. Two consequences, and the second is the harmful one.

## 1. State was written outside the sovereign tree
So it wasn't covered by the per-agent layout, the backups, or Syncthing.

## 2. The test suite was writing to the operator's live store
`tests/test_cli.py::test_seed_plant` invoked `cloud9 seed plant` with **no `--directory`**, so it fell through to that default and planted a **real seed into the live store on every test run**.

**26 accumulated** between 2026-06-28 and today, every one carrying the identical payload `"narrative": "Built Cloud 9"` / `"key_memories": ["First test"]` with a fresh `session_id`. The test already took a `tmp_path` fixture and never used it, and `seed plant` had **no `--directory` option at all**, so it could only ever write to the default.

Same shape as the skcomms fix that landed the same day ("stop tests polluting the live capauth store").

## The fix
`cloud9.paths` is now the single resolver, mirroring `skos.gogbin` for gogcli:

1. `CLOUD9_FEB_DIR` override
2. `~/.skcapstone/agents/<agent>/trust/febs`, agent from the standard `SKAGENT` precedence
3. the legacy path is **never a write target**

`legacy_feb_directory()` exists so a migration can find old data deliberately, and `love_loader` searches sovereign-first with legacy as a **read-only** fallback, so an unmigrated box still finds its love FEB.

Also swept: `cloud9/constants.py`, `src/lib/constants.js` and `src/index.js` each held their own copy of the literal (**four copies across two languages**, the same divergent-constant shape as the GTD file-set bug), and `welcome.py` wrote first-contact state to `~/.openclaw/kingdom`.

`seed plant` gains `--directory`, which is what makes the polluting test fixable at all.

## Verification
- Running the suite now adds **0 files** to the live store (was +1 per run).
- Baseline **3 failed / 228 passed** → now **3 failed / 232 passed**. The same three failures reproduce on pristine `main` in full-suite order: two quantum CLI tests, and one order-dependent integration test. I initially mistook that third one for my own regression, because I'd checked it in isolation rather than in suite order.

## Operator side, already done
`~/.openclaw` is removed. Its contents were archived first, byte-verified, to `~/.skcapstone/archive/openclaw-test-seeds-20260814/` with a README explaining what they are. The 26 test seeds were deliberately **not** promoted into `agents/<agent>/trust/febs/seeds/`: 26 copies of one test payload would pollute the real seed chain. `cloud9-daemon@lumina` restarted clean without the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nuc3axPF4ukouUKABfWFcx