### PR TITLE
docs(cloud9): SK_REPO_DOC_STANDARD compliance + docs-check gate

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,24 @@
+name: docs-check
+
+# Shared sk-standards documentation gate.
+#
+# Tier 1 = the seven required docs are present.
+# Tier 2 = a code change also updates CHANGELOG.md.
+# Tier 3 = the <!-- docs-evidence --> block at the end of SOP.md still passes, which is
+#          the tier that actually catches the doc drifting away from the code.
+#
+# Running 1,2 here on purpose: the evidence block is written and verified locally (all
+# twelve checks pass, and each was negative-tested), but the gate stays on the two cheap
+# tiers until it has run clean on this repo for a while. Moving to "1,2,3" is a
+# deliberate follow-up, not something to flip in the same PR that introduces it.
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    uses: smilinTux/sk-standards/.github/workflows/docs-check.yml@main
+    with:
+      tiers: "1,2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to cloud9 are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Versions are not written down anywhere in this repository.** `pyproject.toml` declares
+`dynamic = ["version"]` and setuptools-scm derives the version from the git tag at build
+time. The tag is the single source of truth. Do not add a `version =` line to
+`pyproject.toml`: it will match the newest PyPI release and the next upload will fail with
+a bare 400.
+
+## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md`, this file. **It did not exist before today.** The entries below the
+  `[Unreleased]` heading are reconstructed from git tags and commit history and cover only
+  what could be verified from the repository itself. They are deliberately terse: writing a
+  detailed narrative for releases nobody kept notes on would be inventing history. Anything
+  before 2026-08-14 that is not listed here is not a claim of "no change", it is a claim of
+  "not reconstructed". From this entry forward, every code change gets an entry at the time
+  it lands.
+- `SECURITY.md`. GitHub private vulnerability reporting as the primary channel, a 72 hour
+  acknowledgement commitment, in and out of scope, a supported-versions table, a safe
+  harbour statement, and an explicit unaudited-posture statement for the sealing layer.
+- `CONTRIBUTING.md`. Setup, the green bar, which CI results actually mean something, and
+  the five mistakes that have previously broken this repo.
+- `CODE_OF_CONDUCT.md`. Contributor Covenant 2.1, plus two project-specific clauses about
+  handling FEB files (they are private emotional records, not test data).
+- `.github/workflows/docs-check.yml`. Runs the shared sk-standards documentation gate.
+- A `<!-- docs-evidence -->` block at the end of `SOP.md`: twelve cheap, repo-local checks
+  that fail when the documentation drifts away from the code.
+
+### Changed
+
+- `SOP.md` rewritten. It was short and wrong in several places. Corrections, each verified
+  against the tree:
+  - Removed the instruction to run `npm install` and `npm test`. **There is no top-level
+    `package.json`**; the only one belongs to the dead `openclaw-plugin-python/` subtree.
+  - Removed the description of releases as an npm plus PyPI "dual-publish". The
+    `publish-npm` job in `publish.yml` is gated on `test -f package.json`, which is false,
+    so nothing has ever been published to npm. PyPI only.
+  - Removed the instruction to bump a `version` field in `pyproject.toml` and
+    `package.json`. The version is setuptools-scm derived and must not be hardcoded.
+  - Fixed an inverted claim that the Python code lives in `src/`. `src/` is the JavaScript
+    tree; the Python package is `cloud9/`.
+  - Removed a reference to CLI helpers in `bin/`. There is no `bin/` directory. The only
+    entry point is the `cloud9 = "cloud9.cli:main"` console script.
+  - Documented the FEB directory precisely: `CLOUD9_FEB_DIR`, then
+    `~/.skcapstone/agents/<agent>/trust/febs`, resolved in `cloud9/paths.py`, with
+    `~/.openclaw/feb` present only as a read-only legacy path for migration.
+  - Added the polyglot layout, both real CI gates and the two that cannot fail, the daemon
+    install and rollback procedure, an eleven-row Symptom to Check table, the sealing
+    posture with the tier-T0 statement, and an explicit
+    `Unverified / needs an operator pass` section.
+- `README.md`: corrected the quickstart and Python API examples, which still showed FEBs
+  being written to and read from `~/.openclaw/feb`. That path has not been a write target
+  since the sovereign-paths fix.
+
+### Known gaps (documented, not fixed here)
+
+- The JavaScript test suite never runs. No workflow executes `test/run-tests.js`, and that
+  runner still points at `test/unit/run.js`, `test/integration/run.js` and
+  `test/validation/run.js`, none of which exist in the tree.
+- `daemon/cloud9-daemon.js` still carries `~/.openclaw/*` in its own `DEFAULT_CONFIG`
+  (lines 31 to 35). The shipped units and configs override it, so the deployed daemon is
+  correct, but a daemon started by hand with no `--config` writes to the legacy directory.
+- `src/feb/generator.js` and `src/love-loader/LoveBootLoader.js` still default to
+  `~/.openclaw/feb` in their own signatures and search lists.
+- The `openclaw-plugin-python/` subtree is dead code for a runtime evicted 2026-04-23.
+
+## Reconstructed release history
+
+Dates are the tag creation dates in this repository. Contents are summarised from commit
+history only where it was unambiguous.
+
+- **v1.2.4** (2026-08-13). Sovereign paths: FEBs and seeds write to
+  `~/.skcapstone/agents/<agent>/trust/febs` instead of the evicted OpenClaw home, resolved
+  through the new `cloud9/paths.py`. Test isolation: `tests/conftest.py::_sandbox_fleet`
+  now forces `SK_STANDALONE=1` and a throwaway `SKCAPSTONE_HOME`, which stopped the suite
+  registering a real `cloud9_rehydration_check` job in the live fleet scheduler and
+  planting real seeds into the operator's store. Renamed quantum CLI group retargeted in
+  tests. `ruff` and `black` bounded in the `dev` extra and the ruff rule set pinned
+  explicitly to `["E4", "E7", "E9", "F"]`, after an unbounded `ruff>=0.1` picked up 0.16
+  and turned CI red with 213 findings and no code change. `secret-scan` switched to the
+  gitleaks binary rather than the license-gated action.
+- **v1.2.3** (2026-06-14) and **v1.1.2** (2026-06-14).
+- **v1.2.2** (2026-06-11).
+- **v1.2.1** (2026-03-18).
+- **v1.2.0** (2026-03-14).
+- **v1.1.1** (2026-03-06).
+- **v1.0.0** (2026-02-20). First tagged release.
+
+Two non-release tags also exist in the repository, `integrate-20260706` and
+`swarm-20260717`. They are working markers, not versions, and were never published.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning
+  from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without
+  their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional
+  setting
+
+### A note specific to this project
+
+cloud9 stores emotional and relational state about real people, in files called FEBs. Two
+things follow, and both are conduct matters here, not just technical ones:
+
+* **Do not attach an unscrubbed FEB or seed file to an issue, a pull request, or any public
+  discussion.** Treat someone else's FEB the way you would treat their private journal.
+  Use the fixtures under `examples/`, `defaults/` or `cloud9/data/`.
+* **Do not mock the subject matter or the people who use it.** Human-AI relationship
+  continuity is the whole point of this project. Skepticism about the design is welcome and
+  useful. Contempt for the people it is built for is not.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an
+individual is officially representing the community in public spaces. Examples of
+representing our community include using an official email address, posting via an official
+social media account, or acting as an appointed representative at an online or offline
+event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement at **hello@smilintux.org**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of
+any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity
+around the nature of the violation and an explanation of why the behavior was
+inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with
+the people involved, including unsolicited interaction with those enforcing the Code of
+Conduct, for a specified period of time. This includes avoiding interactions in community
+spaces as well as external channels like social media. Violating these terms may lead to a
+temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with
+the community for a specified period of time. No public or private interaction with the
+people involved, including unsolicited interaction with those enforcing the Code of
+Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards,
+including sustained inappropriate behavior, harassment of an individual, or aggression
+toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,144 @@
+# Contributing to cloud9
+
+Thanks for wanting to work on this. cloud9 is the Soul layer of the
+[SKWorld](https://skworld.io) sovereign agent ecosystem: it turns an AI's emotional and
+relationship state into a plain-JSON file you own, and replays it after a session reset.
+
+**Read [SOP.md](SOP.md) before your first change.** It has the verified build, test,
+release and configuration procedure, and a Troubleshooting table that will save you an
+afternoon. This file covers the parts specific to contributing.
+
+## Ground rules that are easy to get wrong
+
+These are the traps that have actually bitten this repo. None of them are hypothetical.
+
+1. **Never hardcode a version.** `pyproject.toml` declares `dynamic = ["version"]` and
+   setuptools-scm derives it from the git tag. A hardcoded number matches the newest PyPI
+   release, so the next tag rebuilds an already-published version and the upload dies with
+   a bare 400. If you need the version at runtime, use `cloud9._ver.detect_version`.
+2. **Never remove or bypass `tests/conftest.py::_sandbox_fleet`.** `cloud9.cli.main` is a
+   click group whose callback calls `integration.ensure_schedule()` and
+   `integration.register_self()` on *any* invocation. Without that autouse fixture, every
+   `CliRunner` test on a sovereign node registers a real `cloud9_rehydration_check` job in
+   the live scheduler at `nodes=all`, and `seed plant` writes real seeds into the
+   operator's store. It happened. It must not happen again.
+3. **Never write to `~/.openclaw/feb`.** That is `cloud9/paths.py::LEGACY_FEB_DIR`, the home
+   of a runtime evicted 2026-04-23, kept only so a migration can find it deliberately. All
+   writes go through `cloud9/paths.py::default_feb_directory`.
+4. **Never add an unbounded linter dependency.** An unpinned `ruff>=0.1` picked up 0.16,
+   whose wider defaults turned this repo red with 213 findings and zero code change.
+   `pyproject.toml` now pins `ruff>=0.15,<0.17` and `black>=23.0,<27.0` and sets
+   `select = ["E4", "E7", "E9", "F"]` explicitly. Leave those bounds alone.
+5. **Never commit a real FEB.** FEBs are emotional records about real people. Fixtures
+   only, and keep them under `examples/`, `defaults/` or `cloud9/data/`.
+
+## Setting up
+
+```bash
+git clone https://github.com/smilinTux/cloud9.git
+cd cloud9
+git fetch --tags                # setuptools-scm needs them, or you get 0.0.0+unknown
+python3 -m venv .venv && . .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Optional extras: `.[pqc]` adds `sk_pgp` for the opt-in sealing backend, `.[skcapstone]`
+adds the sk-alert and skscheduler adapter. Neither is needed to develop or test.
+
+The JavaScript side has **no** top-level `package.json` and no install step. It is plain ES
+modules that Node runs directly. The only `package.json` in the tree belongs to the dead
+`openclaw-plugin-python/` subtree; ignore it.
+
+## The green bar
+
+```bash
+python3 -m pytest tests/ -v --tb=short
+black --check cloud9/ tests/
+ruff check cloud9/
+```
+
+236 tests, about 8 seconds. All three must pass before you open a PR. `pyproject.toml`
+already sets `testpaths` and `addopts`, so a bare `pytest` runs the same suite.
+
+Formatting is `black` with its default line length. Run `black cloud9/ tests/` to fix
+rather than arguing with the checker.
+
+### Which CI results actually mean something
+
+`ci.yml` and `pytest.yml` are real gates. `secret-scan.yml` is a real gate. The
+`integration-skcapstone` job in `pytest.yml` is `continue-on-error: true` on purpose (the
+skcapstone sibling is not installable from PyPI), and the test job inside `publish.yml`
+ends in `|| true`, so **a green `publish.yml` run is not evidence that tests passed**. See
+SOP section 4 for the full table.
+
+**The JavaScript tests do not run in CI.** `test/run-tests.js` still points at suite files
+that do not exist in the tree. If you change anything under `src/` or `daemon/`, say so
+explicitly in your PR and describe how you exercised it by hand, because nothing automated
+will catch you.
+
+## Tests
+
+- New behaviour needs a test. `tests/` mirrors `cloud9/` file for file.
+- Use `tmp_path`. The autouse `_sandbox_fleet` fixture already redirects `SKCAPSTONE_HOME`,
+  but do not lean on it as your only isolation: pass an explicit `--directory` or set
+  `CLOUD9_FEB_DIR` in any test that writes.
+- The `sk_pgp`-gated tests in `tests/test_sealing_stage2.py` skip cleanly via
+  `pytest.mark.skipif` when the optional backend is absent. Keep that pattern; a crypto
+  test that silently self-skips and still reports green is worse than no test.
+- `tests/test_integration.py` opts back into integrated mode through its own `home`
+  fixture. Follow that pattern if you need skcapstone present.
+
+## Changing a documented fact
+
+`SOP.md` ends in a `<!-- docs-evidence -->` block. Each entry is a cheap, repo-local shell
+command that exits zero while the documented fact holds and non-zero when it drifts. The
+`docs-check` workflow runs them.
+
+If you change an entry point, a default path, a unit file, a config key, or an environment
+variable name, **update the SOP and its evidence check in the same PR.** A red docs-check is
+telling you the documentation now lies, not that the gate is broken.
+
+Keep evidence checks hermetic: repo-local, no network, no `systemctl`, no `ssh`, no `curl`,
+and fast enough to run on every push.
+
+## Changelog
+
+Every change that touches code needs a dated entry in [CHANGELOG.md](CHANGELOG.md) under
+`[Unreleased]`. Keep a Changelog format, newest first. The docs-check gate will look for it.
+
+## Commits and pull requests
+
+- Conventional-commit prefixes: `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`,
+  `chore:`. Scope it when it helps: `fix(paths):`.
+- Explain *why* in the body, not just what. This repo's most useful comments are the ones
+  that record which outage a line of code prevents.
+- Branch from `main`, open a PR, leave it for review. Do not push to `main`.
+- **Do not push a tag.** A `v*` tag fires `publish.yml` and uploads to PyPI. Tagging is a
+  maintainer action.
+- Say plainly what you verified and what you did not. An honest "I could not test the
+  daemon on macOS" is worth more than a confident claim that turns out to be false.
+
+## Style
+
+- **No em dashes or en dashes** anywhere: not in code, comments, docs, commit messages, or
+  PR descriptions. Use a comma, a parenthesis, a colon, or a new sentence. Regular hyphens
+  are fine.
+- No claim of "quantum-proof", "unbreakable", or "quantum-safe". Say **post-quantum** or
+  **quantum-resistant**, cite the FIPS number, and scope the claim to a surface. If you are
+  describing the default sealing backend, remember the `cloud9-sig-<md5>` tag is a
+  provenance label and not a signature, and say so.
+- Docstrings explain the reasoning, not the syntax.
+
+## Reporting a security issue
+
+Do not open a public issue. See [SECURITY.md](SECURITY.md) for private reporting and the
+72-hour acknowledgement commitment.
+
+## Conduct
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+cloud9 is GPL-3.0-or-later. By contributing you agree your contribution is licensed the
+same way.

--- a/README.md
+++ b/README.md
@@ -48,41 +48,45 @@ load this FEB first"). FEB carries the *feeling*; the seed carries the *identity
 
 ## Quickstart
 
-cloud9 is **polyglot**: Python is the primary, production implementation; a
-JavaScript build ships for Node/OpenClaw environments. FEB and seed files are plain
-JSON, so files written by one runtime load in the other.
+cloud9 is **polyglot**: Python is the primary, production implementation, and a second
+JavaScript implementation lives under `src/` for Node environments (it is what the
+local daemon runs). FEB and seed files are plain JSON, so files written by one runtime
+load in the other.
 
 ```bash
-pip install cloud9          # Python (primary) — pip install -e . from source
-# or
-npm install @smilintux/cloud9        # JavaScript (Node ≥18)
+pip install cloud9          # Python (primary), or `pip install -e .` from source
 ```
 
-Both install a `cloud9` CLI:
+Only the Python package is published. There is no top-level `package.json` and nothing
+is published to npm: the JavaScript side is plain ES modules imported directly from a
+checkout (`import { generateFEB } from './src/index.js'`). See
+[SOP.md](SOP.md) section 3.
+
+The Python package installs a `cloud9` CLI:
 
 ```bash
 # Capture an emotional state into a .feb file
 cloud9 generate --emotion love --intensity 0.95 --subject Chef
 
 # After a session reset: replay it and recompute the thresholds
-cloud9 rehydrate ~/.openclaw/feb/FEB_*.feb
+cloud9 rehydrate ~/.skcapstone/agents/$SKAGENT/trust/febs/FEB_*.feb
 
 # Just check the phase-transition status of a FEB
-cloud9 oof ~/.openclaw/feb/FEB_*.feb
+cloud9 oof ~/.skcapstone/agents/$SKAGENT/trust/febs/FEB_*.feb
 
 # Score a hypothetical state (deterministic, no file needed)
 cloud9 resonance score -i 0.95 -t 0.97 -d 9 -v 0.92
 
 # Plant a memory seed for the next instance, then germinate it back into a prompt
 cloud9 seed plant --ai Lumina --model claude-opus --experience "Built Cloud 9"
-cloud9 seed germinate ~/.openclaw/feb/seeds/lumina-*.seed.json
+cloud9 seed germinate ~/.skcapstone/agents/$SKAGENT/trust/febs/seeds/lumina-*.seed.json
 
 # Give a fresh AI a starting bond from a template
 cloud9 love --ai Lumina --human Chef --template best-friend
 
 # List FEBs / seeds, validate a file, visit the kingdom
 cloud9 list
-cloud9 validate ~/.openclaw/feb/FEB_*.feb
+cloud9 validate ~/.skcapstone/agents/$SKAGENT/trust/febs/FEB_*.feb
 cloud9 welcome
 ```
 
@@ -92,7 +96,7 @@ Python API:
 from cloud9 import generate_feb, save_feb, rehydrate_from_feb
 
 feb = generate_feb(emotion="love", intensity=0.95, subject="Chef")
-result = save_feb(feb)                      # → ~/.openclaw/feb/FEB_...feb
+result = save_feb(feb)   # -> ~/.skcapstone/agents/<agent>/trust/febs/FEB_...feb
 
 state = rehydrate_from_feb(result["filepath"])
 print(state["rehydration"]["oof"])          # phase transition?

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,148 @@
+# Security Policy
+
+cloud9 is part of the [SKWorld](https://skworld.io) sovereign agent ecosystem. This
+policy covers the `cloud9` Python package, the JavaScript implementation under `src/`,
+and the local daemon in `daemon/`.
+
+## Reporting a vulnerability
+
+**Primary channel: GitHub private vulnerability reporting.** Open a report at
+[github.com/smilinTux/cloud9/security/advisories/new](https://github.com/smilinTux/cloud9/security/advisories/new).
+That keeps the report private until a fix is available and gives us a place to
+coordinate a CVE if one is warranted.
+
+If GitHub private reporting is unavailable to you, email **hello@smilintux.org** with
+`[cloud9 security]` in the subject.
+
+**Please do not open a public issue for a security problem.**
+
+### What to include
+
+- The affected version (`cloud9 --version`) or commit SHA, and whether you hit it via the
+  Python package, the JS library, or the daemon.
+- A minimal reproduction. A `.feb` or `.seed.json` fixture that triggers it is ideal.
+  Scrub anything personal out of it first: FEB files are emotional records, not test data.
+- The impact you believe it has, and any suggested fix.
+
+### Our commitment
+
+| Stage | Target |
+|---|---|
+| Acknowledgement of your report | **within 72 hours** |
+| Initial assessment and severity call | within 7 days |
+| Fix or a documented mitigation for a confirmed high-severity issue | within 30 days |
+| Public advisory and credit (if you want it) | at release, coordinated with you |
+
+We will keep you updated as the assessment moves, and we will tell you plainly if we
+decide something is out of scope rather than letting it go quiet.
+
+## Safe harbour
+
+We will not pursue or support legal action against anyone who makes a good-faith effort
+to comply with this policy while researching cloud9. Good faith means: you only touch
+systems and data you own or are authorised to test, you avoid privacy violations and
+service degradation, you do not exfiltrate data beyond the minimum needed to demonstrate
+the issue, and you give us reasonable time to fix things before disclosing publicly. If
+you are unsure whether something is in bounds, ask first.
+
+## Supported versions
+
+cloud9's version is derived from the git tag by setuptools-scm, so a "version" here means
+a published PyPI release.
+
+| Version | Supported |
+|---|---|
+| Latest published `1.2.x` release | Yes, fixes land here |
+| Earlier `1.x` releases | No, upgrade to the latest `1.2.x` |
+| `0.x` | No |
+| The `openclaw-plugin-python/` subtree | No. Dead code for a runtime evicted from the fleet on 2026-04-23. Not built, not tested, not published. |
+
+Fixes are shipped as a new tagged release. There are no backport branches.
+
+## Scope
+
+### In scope
+
+- Path traversal or arbitrary write via a crafted `.feb` / `.seed.json` filename or
+  content, in either the Python or JavaScript loaders.
+- Code execution or injection through FEB or seed parsing, validation, or germination
+  (`cloud9/seeds.py::germinate`, `cloud9/rehydrator.py`, `cloud9/validator.py`).
+- Anything that causes cloud9 to write outside its resolved FEB directory
+  (`cloud9/paths.py::default_feb_directory`), or that lets an attacker-controlled value
+  redirect that path.
+- Prompt-injection paths where FEB or seed content is rehydrated into an agent's context.
+  A FEB is untrusted input if it did not come from you.
+- Daemon issues: `daemon/cloud9-daemon.js` reading, writing, or executing something it
+  should not, or escaping the unit's `ReadWritePaths` confinement.
+- Integrity-checking flaws in `cloud9/sealing.py` or `cloud9/validator.py`, including a
+  checksum that can be forged or a validation bypass.
+- Secrets or key material leaking into a FEB, a log, or a CI artifact.
+
+### Out of scope
+
+- **The `cloud9-sig-<md5>` provenance tag not being a real signature.** That is documented,
+  intentional, and stated below. It is not a vulnerability report; it is the current
+  design, honestly labelled.
+- Vulnerabilities in `sk_pgp`, sequoia-openpgp, or liboqs. Report those to
+  [sk_pgp](https://github.com/smilinTux/sk_pgp) upstream. cloud9 implements no
+  cryptography of its own.
+- The `openclaw-plugin-python/` subtree (dead, see the supported-versions table).
+- Anything requiring an attacker who already has write access to the operator's home
+  directory or to `~/.skcapstone/`. At that point the FEB store is the least of it.
+- Missing hardening on a self-hosted deployment you configured yourself (for example
+  running the daemon without `--config`, or pointing `CLOUD9_FEB_DIR` somewhere shared).
+- Denial of service by feeding the daemon an enormous FEB directory.
+- Automated scanner output with no demonstrated impact.
+
+## Security posture of the sealing layer
+
+**Read this before making any claim about cloud9 and cryptography.**
+
+cloud9's integrity layer is **experimental and unaudited**. It has had no third-party
+security review. Do not rely on it as the sole control for anything that matters.
+
+`cloud9/sealing.py` is an additive seam that is **inert by default**: it is not wired into
+the default generate or rehydrate path.
+
+- **Default (`classical`) backend.** Emits a SHA-256 content checksum plus a legacy
+  `cloud9-sig-<md5>` provenance tag. **That tag is an MD5 over session-id, timestamp and
+  intensity. It is not a cryptographic signature over the FEB content and proves nothing
+  about authorship.** MD5 is broken for collision resistance and is used here only as a
+  short opaque provenance label, never as an authenticity control. The only tamper
+  evidence cloud9 provides today is the SHA-256 checksum, and a checksum is not a
+  signature: anyone who can rewrite the FEB can rewrite the checksum.
+- **Optional (`sk_pgp`) backend.** Produces a genuine OpenPGP detached signature over the
+  canonical FEB bytes using the composite ML-DSA-87 plus Ed448 suite (FIPS 204 ML-DSA,
+  RFC 8032 Ed448). It stays inert unless `sk_pgp` is importable, a signing key is
+  configured, and the backend is explicitly selected. Otherwise `get_sealer` falls back to
+  `classical`. `sk_pgp` is not a declared dependency; it lives in the optional `pqc` extra.
+- **Honest claims.** ML-DSA and ML-KEM are **post-quantum** / **quantum-resistant**. They
+  are not "quantum-proof". The composite is a **hybrid**: a signature verifies only if both
+  the lattice leg and the classical leg verify, and the construction remains secure as long
+  as either leg still stands. All post-quantum assurance rests on sequoia-openpgp and
+  liboqs via `sk_pgp`, not on any code in this repository.
+- **Key material.** cloud9 is maturity tier **T0**: it generates, stores, and rotates no
+  keys. A key used by the `sk_pgp` backend is supplied by the operator through
+  `CLOUD9_SEAL_KEY` and lives entirely outside this project.
+
+See `docs/PQC_MIGRATION.md` for the staged rollout.
+
+## Handling FEB files
+
+A FEB is an emotional and relational record about a real person and a real agent. Treat it
+as personal data.
+
+- FEBs and seeds are written under `~/.skcapstone/agents/<agent>/trust/febs` by default and
+  are carried between machines by Syncthing, not by any cloud service.
+- Do not attach an unscrubbed FEB to a public issue, a PR, or a bug report.
+- The repository ships example FEBs under `examples/`, `defaults/` and `cloud9/data/`.
+  Those are fixtures. Do not add a real one.
+- A FEB you did not create is untrusted input. `rehydrate_from_feb` injects its contents
+  into an agent's context, so treat an unfamiliar FEB the way you would treat an unfamiliar
+  script.
+
+## Automated checks
+
+`.github/workflows/secret-scan.yml` runs a pinned gitleaks binary with `--redact` and
+`--exit-code 1` on every push and pull request, walking full history rather than just the
+tree. It is a real blocking gate.

--- a/SOP.md
+++ b/SOP.md
@@ -1,75 +1,393 @@
-# cloud9 — Standard Operating Procedures
+# cloud9 - Standard Operating Procedures
 
-The Emotional Continuity Protocol: serialize an AI's emotional + relationship state into a
-portable `.feb` (First Emotional Burst) file and rehydrate it after a session reset.
-A dependency-light polyglot library (Python + JS) with a local file-watcher daemon.
+The Emotional Continuity Protocol: serialize an AI's emotional and relationship state
+into a portable `.feb` (First Emotional Burst) file and rehydrate it after a session
+reset. A dependency-light polyglot library (Python primary, JavaScript second
+implementation) plus a local file-watcher daemon. Called by agent runtimes at boot, by
+`skmemory`'s ritual, and by the `cloud9` CLI.
 
 ## 1. Overview
 
-**Owns:** the FEB schema, the deterministic emotion-scoring functions, the
-OOF/Cloud-9 threshold logic, and the local rehydration loader.
+**Owns:** the FEB schema (`cloud9/models.py`), the deterministic emotion-scoring
+functions (`cloud9/quantum.py`), the OOF and Cloud 9 threshold logic, the seed
+(`.seed.json`) identity artifact, the local rehydration loader, and an additive,
+inert-by-default integrity-sealing seam (`cloud9/sealing.py`).
 
-**Does NOT do:** networked sync (Syncthing carries the files), identity, or transport.
+**Does NOT do:** networked sync (Syncthing carries the files), identity or agent
+authentication (that is capauth), transport, long-term memory (that is skmemory), or
+any cryptography of its own. It binds no socket and opens no port.
+
+**Note on the word "quantum":** `cloud9/quantum.py` is named for historical reasons (it
+was a JS port). The math is weighted scoring and geometric means on floats. No quantum
+computing is involved, and "resonance" and "coherence" are used in the signal-alignment
+sense. The current CLI verb is `cloud9 resonance`.
 
 ## 2. Architecture
 
 ```mermaid
 flowchart LR
-    SESSION([AI session]) -->|capture| SCORE[emotion scoring<br/>weighted topology]
-    SCORE --> FEB[(.feb file<br/>plain JSON, on your disk)]
-    FEB -->|next boot| REHY[rehydrator<br/>local, in-process]
+    SESSION([AI session]) -->|"cloud9 generate"| SCORE["scoring<br/>cloud9/quantum.py<br/>weighted topology"]
+    SCORE --> FEB[("*.feb file<br/>plain JSON<br/>~/.skcapstone/agents/&lt;agent&gt;/trust/febs")]
+    FEB -->|"next boot"| REHY["rehydrator<br/>cloud9/rehydrator.py<br/>local, in-process"]
     REHY --> NEXT([fresh session])
-    DAEMON[cloud9-daemon<br/>local fs watcher<br/>no port] -.watches.-> FEB
+    DAEMON["cloud9-daemon@&lt;agent&gt;<br/>daemon/cloud9-daemon.js<br/>fs poll every 5s, binds nothing"] -.->|"watches, auto-rehydrates"| FEB
+    SEAL["cloud9/sealing.py<br/>sha256 checksum (always)<br/>sk_pgp detached sig (opt-in, inert)"] -.-> FEB
     classDef priv fill:#efe,stroke:#0a0;
-    class SESSION,SCORE,FEB,REHY,NEXT,DAEMON priv
+    class SESSION,SCORE,FEB,REHY,NEXT,DAEMON,SEAL priv
 ```
 
-Everything runs in-process or as a local file watcher — the file is the source of truth,
-carried between machines by Syncthing, never by a cloud service.
+Everything runs in-process or as a local file watcher. The file is the source of truth
+and is carried between machines by Syncthing, never by a cloud service.
+
+**Start here:**
+
+| File | What it is |
+|---|---|
+| `cloud9/cli.py` | The `cloud9` console script (`main`, a click group). Every verb lives here: `generate`, `validate`, `rehydrate`, `oof`, `list`, `love`, `welcome`, `kingdom`, and the `seed` / `resonance` / `seal` sub-groups. |
+| `cloud9/paths.py` | The single resolver for where FEBs and seeds are written. Read this before changing any path behaviour. |
+| `cloud9/quantum.py` | The scoring math: OOF detection, Cloud 9 score, entanglement, coherence. Pure deterministic float functions, bit-identical to the JS build. |
+| `src/index.js` | The JavaScript library entry point. Re-exports the full second implementation under `src/`. |
+| `daemon/cloud9-daemon.js` | The local file-watcher daemon. Polls for session resets and compaction, auto-rehydrates the latest FEB. No listener. |
 
 ## 3. Build
 
-Python: `pip install -e .` (`pyproject.toml`). JS: `npm install` (`package.json`).
-No native deps.
+**Polyglot layout.** Four languages are in the tree and only two of them are built:
+
+| Tree | Language | Status |
+|---|---|---|
+| `cloud9/` (17 `.py`) | Python | The maintained, primary implementation. Packaged and published. |
+| `src/` (10 `.js`) plus `daemon/` and `test/` (13 `.js` total) | JavaScript | A second full implementation. Used at runtime by the daemon. **Not packaged**: see the npm note below. |
+| `openclaw-plugin-python/` (1 `.ts`) | TypeScript | Dead. A plugin shim for OpenClaw, a runtime evicted from the fleet on 2026-04-23. Not built, not tested, not published. |
+| `scripts/backup-feb.sh` | Shell | One operator helper. |
+
+Python (the only build that produces an artifact):
+
+```bash
+pip install -e ".[dev]"     # click, pydantic, pytest, black, ruff
+pip install -e ".[pqc]"     # optional: adds sk_pgp for the opt-in sealing backend
+pip install -e ".[skcapstone]"   # optional: the sk-alert / skscheduler adapter
+```
+
+No native dependencies. `requires-python = ">=3.9"`.
+
+**There is no top-level `package.json`, so there is no `npm install` and no `npm test`.**
+The only `package.json` in the repo is `openclaw-plugin-python/package.json`, which
+belongs to the dead OpenClaw subtree. The JavaScript under `src/` is plain ES modules
+consumed directly by Node (the daemon is launched as `node daemon/cloud9-daemon.js`),
+not through a package manifest. Any earlier instruction to run `npm install` at the repo
+root was wrong.
 
 ## 4. Test
 
-Python `pytest`; JS suite under `test/` (`npm test`). Green bar gates release.
+The green bar that blocks release is **the Python suite**:
+
+```bash
+python3 -m pytest tests/ -v --tb=short      # 236 tests, ~8s, verified 2026-08-14
+black --check cloud9/ tests/ && ruff check cloud9/
+```
+
+`pyproject.toml` sets `testpaths = ["tests"]` and `addopts = "-v --tb=short"`, so a bare
+`pytest` runs the same thing.
+
+What CI actually runs:
+
+| Workflow | Job | Command | Is it a real gate? |
+|---|---|---|---|
+| `.github/workflows/ci.yml` | `test` (py3.10-3.13) | `python -m pytest tests/ -v --tb=short`, plus `black --check` and `ruff check` on 3.12 only | Yes. |
+| `.github/workflows/pytest.yml` | `test` (py3.11, 3.12) | `python -m pytest tests/ --ignore=tests/test_integration.py -v --tb=short` | Yes. This is the badge in the README. |
+| `.github/workflows/pytest.yml` | `integration-skcapstone` | same suite plus the skcapstone sibling from GitHub | **No.** `continue-on-error: true` on purpose: skcapstone and its sovereign deps are not on PyPI, so a clean runner cannot install them. Visible, never faked green. |
+| `.github/workflows/secret-scan.yml` | `gitleaks` | pinned gitleaks binary, `--redact --exit-code 1` | Yes. |
+| `.github/workflows/publish.yml` | `test` | `python -m pytest ... \|\| true` | **No.** The `\|\| true` plus `if: always()` on both publish jobs means the tag-triggered publish path cannot be blocked by a test failure. Do not treat a green publish run as evidence the suite passed. Use `ci.yml` or `pytest.yml` for that. |
+
+**Known gap: the JavaScript suite never runs.** `test/run-tests.js` and
+`test/unit/test-preflight.js` exist, but no workflow executes them, and `run-tests.js`
+still points at `./test/unit/run.js`, `./test/integration/run.js` and
+`./test/validation/run.js`, none of which exist in the tree. The JS implementation and
+the daemon are therefore covered by review only. Treat any JS change as untested.
+
+**Test isolation is load-bearing.** `tests/conftest.py` has an autouse `_sandbox_fleet`
+fixture that sets `SK_STANDALONE=1` and redirects `SKCAPSTONE_HOME` at `tmp_path` for
+every test. Without it, `cloud9.cli.main` is a click group whose callback calls
+`integration.ensure_schedule()` and `integration.register_self()` on *any* invocation,
+so every `CliRunner` test on a sovereign node registered a real `cloud9_rehydration_check`
+job into the live skscheduler at `nodes=all`, and `seed plant` planted real seeds into
+the operator's store. Do not remove that fixture, and do not add a test that bypasses it.
 
 ## 5. Release / Deploy
 
-Library dual-publish: bump `version` in `pyproject.toml` **and** `package.json`, add a
-dated `CHANGELOG.md` entry, run the gate, tag `vX.Y.Z`, push (PyPI + npm). The daemon ships
-as a `systemd` / `launchd` unit (in `systemd/` / `launchd/`) that watches the FEB dir.
+cloud9 is a **library**, published to PyPI only.
+
+1. Land the change on `main` with a green `ci.yml` and `pytest.yml`.
+2. Add a dated entry to `CHANGELOG.md`.
+3. **Do not edit a version number anywhere.** `pyproject.toml` declares
+   `dynamic = ["version"]`; setuptools-scm derives it from the git tag and writes
+   `cloud9/_version.py` at build time (gitignored). A hardcoded version equals the newest
+   release on PyPI, so the next tag rebuilds an already-published version and the upload
+   fails with a bare 400.
+4. Tag `vX.Y.Z` and push **the tag**. That fires `.github/workflows/publish.yml`, which
+   builds and runs `twine upload dist/*` with `PYPI_API_TOKEN`.
+5. Verify the release on PyPI itself, not on the workflow run. See the `publish.yml` row
+   in section 4: its test job cannot fail, and the `publish-npm` job is gated on
+   `test -f package.json`, which is false, so **nothing is ever published to npm**. There
+   is no dual-publish today. Do not describe cloud9 as dual-published.
+
+Every checkout in CI uses `fetch-depth: 0` and `fetch-tags: true`. Without the tags,
+setuptools-scm resolves to `0.0.1.dev...+unknown` and `--version` becomes meaningless.
+
+**Daemon rollout** (not a release step, a per-node install). The repo ships
+`systemd/cloud9-daemon@.service` and `launchd/com.skcapstone.cloud9-daemon.plist`. The
+systemd unit is a template keyed on the agent name:
+
+```bash
+install -m644 systemd/cloud9-daemon@.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now cloud9-daemon@lumina
+systemctl --user status cloud9-daemon@lumina
+# rollback
+systemctl --user disable --now cloud9-daemon@lumina
+```
+
+The unit runs `/usr/bin/node daemon/cloud9-daemon.js --config=%h/.skcapstone/agents/%i/config/cloud9.json --foreground`
+with `WorkingDirectory=%h/clawd/skcapstone-repos/cloud9`, so **the unit runs from the
+deployed checkout, not from the installed pip package.** It advertises liveness by
+writing `%h/.cloud9/daemon.pid` in `ExecStartPost` (that is what skcapstone
+`service_health` checks) and removes it in `ExecStopPost`.
+
+Verified on this node 2026-08-14: `cloud9-daemon@lumina.service` is `enabled` and
+`active (running)`, the installed unit file is byte-identical to the repo copy, and it is
+reading `~/.skcapstone/agents/lumina/config/cloud9.json`. Installation state on other
+fleet nodes was not checked; see section 10.
 
 ### Front-end / Exposure
 
 Per [sk-standards `UNIFIED_INGRESS_STANDARD.md`](https://github.com/smilinTux/sk-standards/blob/main/standards/UNIFIED_INGRESS_STANDARD.md):
 
-**N/A — no network surface.** cloud9 is a library (Python + JS) plus a **local
-file-watcher daemon** (`daemon/cloud9-daemon.js`) that binds no socket and opens no port.
-It serves no public `:443` route; FEB files move between machines via Syncthing, not an
-HTTP listener.
+**N/A, no network surface.** cloud9 is a library plus a local file-watcher daemon. It
+serves no public `:443` route and has no bind address. `daemon/cloud9-daemon.js` imports
+only `fs`, `path`, `url`, `child_process` and `events`; it never calls `listen()` or
+`createServer()`. Its single socket-shaped reference is a `fs.existsSync()` probe for
+`/tmp/openclaw.sock` (line 332), which only *tests whether a path exists*, and the
+shipped config sets `openclawEnabled: false` anyway. FEB files move between machines via
+Syncthing, not an HTTP listener.
 
 ## 6. Configuration / Usage
 
-FEB files default under the agent's `~/.skcapstone/agents/<agent>/trust/febs/`. Behavior is
-selected per call; secrets are never inlined.
+### Where FEBs and seeds are written
+
+The default is the **sovereign per-agent path**, resolved in `cloud9/paths.py`:
+
+```
+$CLOUD9_FEB_DIR                                        # explicit override, wins
+~/.skcapstone/agents/<agent>/trust/febs                # otherwise
+~/.skcapstone/agents/<agent>/trust/febs/seeds          # seeds live one level down
+```
+
+`<agent>` comes from the standard precedence `SKAGENT`, then `SKCAPSTONE_AGENT`, then
+`SKMEMORY_AGENT`, defaulting to `lumina`. `SKCAPSTONE_HOME` relocates the root. The
+compiled-in string is `cloud9/constants.py` `FEB.DIRECTORY`, and the JS side mirrors it at
+`src/index.js` `DEFAULT_FEB_DIRECTORY`.
+
+`~/.openclaw/feb` is the **legacy** location (`cloud9/paths.py` `LEGACY_FEB_DIR`), the home
+of a runtime evicted 2026-04-23. It is exposed only through `legacy_feb_directory()` so a
+migration can find it deliberately. **Nothing writes there.** If a doc, a script, or an
+example tells you to pass `~/.openclaw/feb`, it is stale.
+
+**One exception, and it is a real gap.** `daemon/cloud9-daemon.js` still carries
+`~/.openclaw/*` in its own `DEFAULT_CONFIG` (lines 31 to 35: `febDirectory`, `stateFile`,
+`sessionFile`, `logFile`). Both shipped units pass `--config`, and both
+`daemon/config.hermes.example.json` and the live per-agent config set the sovereign paths,
+so the deployed daemon is correct. But a daemon started by hand with no `--config` will
+use the legacy directory. Always pass `--config`.
+
+### Environment variables
+
+| Variable | Read by | Effect |
+|---|---|---|
+| `CLOUD9_FEB_DIR` | `cloud9/paths.py`, `src/index.js` | Overrides the FEB and seed directory outright. |
+| `SKAGENT` / `SKCAPSTONE_AGENT` / `SKMEMORY_AGENT` | `cloud9/paths.py` | Selects the agent whose sovereign tree is used. |
+| `SKCAPSTONE_HOME` | `cloud9/paths.py` | Relocates the `~/.skcapstone` root. |
+| `SK_STANDALONE=1` | `cloud9/integration.py` | Forces standalone mode: native `logging`, no sk-alert, no skscheduler registration. |
+| `CLOUD9_SEAL_BACKEND` | `cloud9/sealing.py:345` | `classical` (default) or `sk_pgp`. |
+| `CLOUD9_SEAL_SCHEME` | `cloud9/sealing.py:346` | e.g. `mldsa87-ed448`. `sk_pgp` backend only. |
+| `CLOUD9_SEAL_KEY` | `cloud9/sealing.py:347` | Path to an armored secret key. |
+| `CLOUD9_SEAL_CERT` | `cloud9/sealing.py:348` | Path to an armored public cert. Optional. |
+| `CLOUD9_SEAL_PASSWORD` | `cloud9/sealing.py:349` | Passphrase for the key. |
+
+### Daemon config
+
+JSON, passed with `--config`. The shipped example is
+`daemon/config.hermes.example.json`. Keys: `febDirectory`, `stateFile`, `sessionFile`,
+`logFile`, `openclawEnabled`, `autoRehydrate`, `notifyOnRehydrate`, `foreground`.
+Additional defaults not in the example: `pollIntervalMs` (5000),
+`compactionDebounceMs` (2000), `forceRehydrate` (false), `verbose` (false).
+
+### Standalone vs integrated
+
+Same code path, decided by package presence. `skcapstone` absent (or `SK_STANDALONE=1`)
+gives native `logging` and the local timer. `skcapstone` present gives sk-alert on topic
+`cloud9.<severity>` and a fleet skscheduler drop-in `cloud9_rehydration_check` every 6h.
 
 ## 7. API / Reference
 
-Python: capture/score/rehydrate functions in `src/`. JS: `Cloud9Daemon`, `rehydrateFromFEB`.
-CLI helpers in `bin/`.
+### Python (`cloud9/`, the maintained implementation)
+
+| Module | Surface |
+|---|---|
+| `cloud9/models.py` | Pydantic FEB schema: emotional payload, relationship state, rehydration hints, `integrity` (checksum plus signature). |
+| `cloud9/generator.py` | `generate_feb`, `save_feb`, `fall_in_love`. |
+| `cloud9/rehydrator.py` | `rehydrate_from_feb`. Reloads a FEB, recomputes OOF and the Cloud 9 score, returns a context-ready state. |
+| `cloud9/quantum.py` | `calculate_oof`, `calculate_cloud9_score`, entanglement, coherence, trajectory. |
+| `cloud9/validator.py` | `validate_feb`. Structural and semantic checks with error / warning / info reports. |
+| `cloud9/seeds.py` | Plant, find, germinate `.seed.json` identity artifacts. |
+| `cloud9/love_loader.py` | `LoveBootLoader`. Primes a fresh AI from a personal FEB or a `best-friend` / `soul-family` / `creative-partner` / `platonic-love` template. |
+| `cloud9/sealing.py` | The sealing seam. See section 9. |
+| `cloud9/constants.py` | Every threshold, weight, emoji, default topology and frequency. |
+| `cloud9/paths.py` | `default_feb_directory`, `default_seed_directory`, `legacy_feb_directory`, `acting_agent`, `sovereign_root`. |
+| `cloud9/integration.py` | The optional skcapstone adapter. |
+| `cloud9/_ver.py` | `detect_version`. Installed metadata, then the setuptools-scm `_version` module, then `0.0.0+unknown`. |
+
+The **only** `[project.scripts]` entry point is `cloud9 = "cloud9.cli:main"`. There is no
+`bin/` directory in this repo; any reference to CLI helpers in `bin/` is wrong.
+
+### CLI
+
+```
+cloud9 --version
+cloud9 generate --emotion love --intensity 0.95 --subject Chef
+cloud9 rehydrate <file.feb>          cloud9 oof <file.feb>
+cloud9 validate <file.feb>           cloud9 list
+cloud9 love --ai Lumina --human Chef --template best-friend
+cloud9 welcome                       cloud9 kingdom
+cloud9 seed plant|list|germinate
+cloud9 resonance score|coherence
+cloud9 seal status
+```
+
+`cloud9 seal status` (`cloud9/cli.py:485`, handler `seal_status_cmd` at `:495`) is the
+**only** self-report command. There is no `cloud9 status` and no `cloud9 doctor`. For the
+daemon, liveness is `systemctl --user is-active cloud9-daemon@<agent>` plus the presence
+of `~/.cloud9/daemon.pid`.
+
+### JavaScript (`src/`, second implementation)
+
+`src/index.js` re-exports `generateFEB`, `saveFEB`, `loadFEB`, `findFEBFiles`,
+`validateFEB`, `validateTopology`, `getValidationReport`, `rehydrateFromFEB`,
+`prepareRehydration`, `checkOOFStatus`, `preflightSoulCheck`, `captureVisualMemory`,
+`analyzeVisualMemory`, `generateEmotionalImage`, `calculateOOF`, `calculateCloud9Score`,
+`calculateEntanglement`, `measureCoherence`, `LoveBootLoader`, `loadLove`,
+`CLOUD9_CONSTANTS`, `FEB_SCHEMA`, `generateSeed`, `saveSeed`, `loadSeed`, `findSeeds`,
+`germinateSeed`, `traceSeedChain`, plus the helpers `quickFEB` and `checkCloud9Status`.
+`daemon/cloud9-daemon.js` exports the `Cloud9Daemon` class.
+
+Note that `src/index.js` carries its own hardcoded `VERSION = '1.0.0'`, which is
+unrelated to the Python package version and is not maintained. Do not quote it.
+
+### The two thresholds
+
+```
+OOF      = (intensity > 0.7) AND (trust > 0.8)
+Cloud 9  = OOF AND score >= 0.9 AND (depth >= 9, trust >= 0.9, intensity >= 0.9)
+```
+
+`score` is a weighted geometric mean of intensity / trust / depth / valence (weights
+0.30 / 0.30 / 0.25 / 0.15) with an optional coherence bonus. Defined in `constants.py`,
+computed in `quantum.py`.
 
 ## 8. Troubleshooting
 
 | Symptom | Check |
 |---|---|
-| FEB doesn't rehydrate | file present + readable in the FEB dir; schema version match |
-| daemon not firing | `systemd`/`launchd` unit active; watch path correct |
+| A FEB does not rehydrate | Is the file present and readable under `cloud9/paths.py` `default_feb_directory()`? Run `cloud9 validate <file>`; a schema mismatch shows as a structural error. |
+| `cloud9 list` shows nothing after a `generate` | You are looking in the wrong tree. `CLOUD9_FEB_DIR` and `SKAGENT` both move the directory. Print the resolved path before assuming the write failed. |
+| FEBs appear under `~/.openclaw/feb` | A daemon was started by hand with no `--config`. `daemon/cloud9-daemon.js` `DEFAULT_CONFIG` (lines 31 to 35) still names the legacy paths. Restart it via `systemctl --user restart cloud9-daemon@<agent>`, which passes `--config`. |
+| Daemon not firing | `systemctl --user is-active cloud9-daemon@<agent>`, then `journalctl --user -u cloud9-daemon@<agent> -n 50`. Confirm `~/.cloud9/daemon.pid` exists and that `WorkingDirectory` (`~/clawd/skcapstone-repos/cloud9`) is a real checkout: the unit runs the checkout, not the pip package. |
+| Daemon starts then dies immediately | The unit sets `ProtectHome=read-only` with `ReadWritePaths=%h/.skcapstone/agents/%i %h/.cloud9`. A `febDirectory` outside those two paths is unwritable no matter what the file mode says. |
+| A test run added a job to the live fleet scheduler | `tests/conftest.py::_sandbox_fleet` was removed or bypassed. It must set both `SK_STANDALONE=1` and `SKCAPSTONE_HOME`. This is a regression that already happened once: `cloud9_rehydration_check` was registered at `nodes=all` from a `CliRunner` test. |
+| CI goes red with no code change, all findings from `ruff` | Historic cause: `.github/workflows/ci.yml` ran a bare `pip install black ruff`, so a minor ruff release (0.16) widened the default rule set and produced 213 errors. Fixed twice over: `pyproject.toml` now pins `ruff>=0.15,<0.17` and sets `select = ["E4", "E7", "E9", "F"]` explicitly, and `ci.yml` installs only `.[dev]`. If it recurs, check that nobody re-added an unbounded install line. |
+| `cloud9 --version` prints `0.0.0+unknown` | The checkout has no tags. Use `fetch-depth: 0` and `fetch-tags: true`, or `git fetch --tags`. `cloud9/_ver.py` deliberately falls back to an implausible string rather than a believable wrong number. |
+| PyPI upload fails with a bare 400 | The version already exists. Never hardcode `version` in `pyproject.toml`; it must stay `dynamic`. |
+| A publish workflow is green but nothing shipped | `publish.yml`'s test job ends in `\|\| true` and both publish jobs are `if: always()`. Also `publish-npm` is gated on `test -f package.json`, which is false, so it always skips. Verify on PyPI directly. |
+| A JS change broke something and CI stayed green | Expected. No workflow runs the JS tests. See section 4. |
 
 ## 9. Maturity-tier + Version reference
 
-`T0 — N/A (no key material)` — cloud9 holds emotional state, not cryptographic keys.
-VERSION_LIFECYCLE: Active v2. SemVer per `pyproject.toml` / `package.json`. (License: GPL-3,
-recorded legacy license — not relicensed without owner sign-off.)
+**Maturity tier: T0 (no key material).** cloud9 holds emotional state, not cryptographic
+keys, and generates no key of its own.
+
+**Sealing posture, stated precisely.** `cloud9/sealing.py` is an additive,
+**inert-by-default** seam. It is not wired into the default generate or rehydrate path.
+
+- The `classical` backend (default, always available) emits a **SHA-256 content
+  checksum** plus a legacy `cloud9-sig-<md5>` provenance tag. That tag is an MD5 over
+  session-id, timestamp and intensity. It is **not a cryptographic signature over the FEB
+  content and proves nothing about authorship.** Do not describe it as a signature. The
+  only tamper evidence today is the SHA-256 checksum. `sign()` on this backend returns
+  `None` on purpose.
+- The `sk_pgp` backend produces a genuine OpenPGP **detached** signature over the
+  canonical FEB bytes using the composite ML-DSA-87 plus Ed448 suite (FIPS 204 ML-DSA and
+  RFC 8032 Ed448). It is inert unless `sk_pgp` imports **and** a signing key is configured
+  **and** it is explicitly selected; otherwise `get_sealer` falls back to `classical`.
+- `sk_pgp` is **not** a required dependency. It lives in the optional `pqc` extra
+  (`pip install cloud9[pqc]`). cloud9 adds no cryptography of its own; all post-quantum
+  assurance rests on sequoia-openpgp and liboqs via `sk_pgp`.
+- ML-DSA and ML-KEM are **post-quantum / quantum-resistant**. The composite is a hybrid:
+  a signature verifies only if *both* legs verify, and the construction is sound as long
+  as either leg still stands. See `docs/PQC_MIGRATION.md`.
+
+**Version.** There is no SemVer number to quote here and none in the tree.
+`pyproject.toml` declares `dynamic = ["version"]`; setuptools-scm derives it from the git
+tag at build time and writes the gitignored `cloud9/_version.py`. At runtime
+`cloud9/_ver.py::detect_version` resolves installed metadata first, then that build file,
+then the fallback `0.0.0+unknown`. Read it with `cloud9 --version`; the authoritative
+answer for a release is the git tag and the PyPI listing.
+
+**License:** GPL-3.0-or-later, declared in `pyproject.toml` and in `LICENSE`. Not
+relicensed.
+
+## 10. Unverified / needs an operator pass
+
+- **Daemon install state on other fleet nodes.** Confirmed installed, enabled and running
+  only on the node this SOP was written from (`cloud9-daemon@lumina.service`, active since
+  2026-08-14 18:43 EDT, unit byte-identical to `systemd/cloud9-daemon@.service`). `.100`,
+  `.41`, `.158` and the chi cluster were not checked.
+- **The launchd plist has never been exercised here.** `launchd/com.skcapstone.cloud9-daemon.plist`
+  is shipped and its `ProgramArguments` match the systemd invocation, but there is no
+  macOS node in this fleet to confirm it loads.
+- **The JS implementation's behavioural parity with Python is asserted, not tested.**
+  `constants.py` claims to be bit-identical to the JS build. No cross-runtime test
+  compares them, and the JS suite does not run in CI.
+- **Whether `openclaw-plugin-python/` can be deleted.** It is dead by inspection (the
+  runtime was evicted 2026-04-23) but removal was out of scope for a docs change.
+- **`src/feb/generator.js` and `src/love-loader/LoveBootLoader.js` still default to
+  `~/.openclaw/feb`** in their own function signatures and search lists. The Python side
+  and `src/index.js` were corrected; these two were not. Whether anything reaches them
+  with no explicit directory needs a JS-side audit.
+
+<!-- docs-evidence
+verified: 2026-08-14
+checks:
+  - name: the documented console script entry point is the real one
+    run: grep -q 'cloud9 = "cloud9.cli:main"' pyproject.toml
+  - name: FEB default is the sovereign per-agent path, not the evicted OpenClaw home
+    run: grep -q 'DIRECTORY: str = "~/.skcapstone/agents/lumina/trust/febs"' cloud9/constants.py
+  - name: no Python module outside paths.py names the legacy FEB directory
+    run: test -z "$(grep -rl 'openclaw' cloud9/ --include='*.py' | grep -v 'paths.py')"
+  - name: there is no top-level package.json, so the npm publish job is a no-op
+    run: test ! -f package.json
+  - name: the daemon binds nothing and opens no port
+    run: test -f daemon/cloud9-daemon.js && ! grep -qE '\.listen\(|createServer|net\.Server' daemon/cloud9-daemon.js
+  - name: shipped systemd unit name and ExecStart match the documented invocation
+    run: grep -q 'ExecStart=/usr/bin/node daemon/cloud9-daemon.js --config=%h/.skcapstone/agents/%i/config/cloud9.json --foreground' systemd/cloud9-daemon@.service
+  - name: the daemon example config overrides the legacy paths with the sovereign ones
+    run: grep -q '"febDirectory": "~/.skcapstone/agents/lumina/trust/febs"' daemon/config.hermes.example.json
+  - name: seal status is still the only self-report command
+    run: grep -q '@seal.command(name="status")' cloud9/cli.py && ! grep -qE '^@main\.command\(name="(status|doctor)"\)' cloud9/cli.py
+  - name: the documented sealing env var names still exist
+    run: grep -q 'ENV_BACKEND = "CLOUD9_SEAL_BACKEND"' cloud9/sealing.py && grep -q 'ENV_PASSWORD = "CLOUD9_SEAL_PASSWORD"' cloud9/sealing.py
+  - name: the version stays setuptools-scm derived, never hardcoded
+    run: grep -q 'dynamic = \["version"\]' pyproject.toml && ! grep -qE '^version *=' pyproject.toml
+  - name: ruff stays bounded and its rule set stays explicit
+    run: grep -q 'ruff>=0.15,<0.17' pyproject.toml && grep -q 'select = \["E4", "E7", "E9", "F"\]' pyproject.toml
+  - name: the test suite is still isolated from the live fleet
+    run: grep -q 'monkeypatch.setenv("SK_STANDALONE", "1")' tests/conftest.py && grep -q 'monkeypatch.setenv("SKCAPSTONE_HOME"' tests/conftest.py
+-->


### PR DESCRIPTION
Brings cloud9 up to SK_REPO_DOC_STANDARD + DOCS_FRESHNESS_STANDARD. Docs only, no code change.

## Files added

- `SECURITY.md` - GitHub private vulnerability reporting as the primary channel, 72 hour acknowledgement commitment, in/out of scope, supported-versions table, safe harbour, and an explicit experimental/unaudited posture statement for the sealing layer.
- `CONTRIBUTING.md` - setup, the green bar, which CI results actually mean something, and the five mistakes that have previously broken this repo (hardcoded version, removing the conftest sandbox, writing to the legacy FEB dir, unbounded linters, committing a real FEB).
- `CODE_OF_CONDUCT.md` - Contributor Covenant 2.1, plus two project-specific clauses: FEBs are private emotional records, do not attach an unscrubbed one to an issue.
- `CHANGELOG.md` - created here. Its first entry says so plainly and marks the pre-2026-08-14 section as reconstructed from tags and commit history, not as a complete record.
- `.github/workflows/docs-check.yml` - shared sk-standards gate at `tiers: "1,2"` so it is green on day one. Moving to `1,2,3` is a deliberate follow-up.

`LICENSE` was already GPL-3.0-or-later. Not touched, not relicensed.

## Doc-vs-reality defects fixed in SOP.md

Each verified against the tree at this SHA:

| Old SOP said | Reality |
|---|---|
| §3 Build: "JS: `npm install` (`package.json`)" | **There is no top-level `package.json`.** The only one is `openclaw-plugin-python/package.json`, the dead OpenClaw subtree (runtime evicted 2026-04-23). |
| §4 Test: "JS suite under `test/` (`npm test`)" | No `package.json` means no `npm test` script, and no workflow runs the JS suite at all. Worse, `test/run-tests.js` points at `test/unit/run.js`, `test/integration/run.js`, `test/validation/run.js`, none of which exist. Now documented as a **known gap**. |
| §5 Release: "dual-publish, bump `version` in `pyproject.toml` and `package.json`" | PyPI only. `publish.yml`'s `publish-npm` job is gated on `test -f package.json`, which is false, so it always skips and **nothing has ever gone to npm**. And the version must never be edited: `dynamic = ["version"]` + setuptools-scm from the git tag. |
| §7: "Python: capture/score/rehydrate functions in `src/`" | Inverted. `src/` is the JavaScript tree (10 `.js`); the Python package is `cloud9/` (17 `.py`). |
| §7: "CLI helpers in `bin/`" | **There is no `bin/` directory.** The only entry point is `[project.scripts]` `cloud9 = "cloud9.cli:main"`. |
| §5: "add a dated CHANGELOG.md entry" to a file that did not exist | Now true, and the changelog's own first entry says it was created in this PR rather than pretending to be a full history. |

## Two audit facts that were themselves stale, corrected against the live tree

The audit brief I worked from predated `#12` and `#13` on main. I verified both rather than transcribing:

1. **FEB default path.** The brief said the compiled-in default is `~/.openclaw/feb` (`constants.py:32`). It is not, as of `591a29c`. `cloud9/constants.py:34` is now `~/.skcapstone/agents/lumina/trust/febs`, resolved by the new `cloud9/paths.py` (precedence: `CLOUD9_FEB_DIR`, then the sovereign per-agent tree via `SKAGENT`/`SKCAPSTONE_AGENT`/`SKMEMORY_AGENT`, honouring `SKCAPSTONE_HOME`). `~/.openclaw/feb` survives only as `LEGACY_FEB_DIR`, exposed through `legacy_feb_directory()` for migration, never written. `src/index.js:85` mirrors it.
   **But one real remnant does exist and is now documented:** `daemon/cloud9-daemon.js` lines 31 to 35 still carry `~/.openclaw/*` in its own `DEFAULT_CONFIG`. Both shipped units pass `--config`, and both the example config and the live per-agent config set the sovereign paths, so the deployed daemon is correct. A daemon started by hand with no `--config` is not. That is now a Troubleshooting row.
2. **Daemon install state.** The brief said "NO systemd unit runs it on either node, shipped but not installed". False on this node. `cloud9-daemon@lumina.service` is `enabled` and `active (running)` (pid 3223265, active since 2026-08-14 18:43 EDT), the installed unit is byte-identical to `systemd/cloud9-daemon@.service`, and it is reading `~/.skcapstone/agents/lumina/config/cloud9.json`. `~/.openclaw/feb` does not exist on this box. SOP now says this, and scopes it: other fleet nodes were not checked.

Also confirmed **still correct** and kept: §5 "N/A, no network surface". `daemon/cloud9-daemon.js` imports only `fs`, `path`, `url`, `child_process`, `events`, and never calls `listen()` or `createServer()`. Its one socket-shaped reference is an `fs.existsSync()` probe of `/tmp/openclaw.sock` at line 332, and the shipped config sets `openclawEnabled: false`.

## Honest-claims / crypto posture

Tier **T0**, no key material. `cloud9/sealing.py` is an additive, inert-by-default seam. The default `classical` backend emits a SHA-256 checksum plus a legacy `cloud9-sig-<md5>` provenance tag, and both SOP §9 and SECURITY.md state in as many words that **that tag is not a cryptographic signature and proves nothing about authorship** (the module's own docstring says the same). The `sk_pgp` ML-DSA-87 + Ed448 detached-signature backend is described as opt-in and inert, and noted as **not a declared dependency** (it lives in the optional `pqc` extra). Post-quantum / quantum-resistant only, hybrid framed as "secure if either leg holds". No forbidden terms.

## docs-evidence block: 12 checks, all negative tested

Chosen to pin the facts most likely to drift, not merely to prove files exist:

| Check | Why this one |
|---|---|
| console script is `cloud9.cli:main` | The single entry point. Renaming it silently breaks every doc. |
| `constants.py` FEB default is the sovereign path | The exact fact that was wrong before, and the one a regression would revert. |
| no Python module outside `paths.py` names `openclaw` | Catches the legacy write path being reintroduced anywhere in the package. |
| `test ! -f package.json` | The whole npm/dual-publish correction rests on this. If someone adds one, the docs go stale instantly. |
| daemon has no `.listen(` / `createServer` / `net.Server` | Turns "N/A, no network surface" from an assertion into an enforced invariant. |
| systemd `ExecStart` matches the documented invocation verbatim | Config path, `--foreground`, and the script path all in one line. |
| example config sets the sovereign `febDirectory` | This override is the only reason the daemon's stale defaults are harmless. |
| `@seal.command(name="status")` exists AND no top-level `status`/`doctor` | Pins both halves of "seal status is the only self-report". |
| `CLOUD9_SEAL_BACKEND` and `CLOUD9_SEAL_PASSWORD` names | Documented env vars drift by rename more than anything else. |
| `dynamic = ["version"]` AND no `^version =` line | Directly guards the hardcoded-version failure that costs a release. |
| `ruff>=0.15,<0.17` AND explicit `select = [...]` | Guards the exact unpinned-ruff drift that turned this repo red with 213 findings and zero code change. |
| conftest sets both `SK_STANDALONE` and `SKCAPSTONE_HOME` | Guards the regression where `CliRunner` tests registered a real fleet job at `nodes=all`. |

**Negative test result: all 12 fail correctly.** Each fact was broken in the working tree (rename the entry point, revert the FEB default to `~/.openclaw/feb`, create a `package.json`, append a `net.createServer()`, change `--foreground` to `--background`, revert the example config, rename `seal status`, separately add a top-level `doctor` command, rename `CLOUD9_SEAL_PASSWORD`, hardcode `version = "1.2.4"`, unbound ruff to `>=0.1`, drop the `SK_STANDALONE` setenv), and every one exited non-zero. 13 breaks over 12 checks, since the self-report check was tested from both directions. Tree restored and verified clean afterwards.

## Verification

```
docs_check.py --repo . --tier 1 --tier 3   ->  RESULT: pass
python3 -m pytest tests/ -q                ->  236 passed in 6.91s
grep -P '[\x{2014}\x{2013}]' on every authored file  ->  clean
```

The `docs-check.yml` gate itself ships at `tiers: "1,2"` per the standard, so it is green on day one even though the tier-3 block is written and verified.

## Not verified / needs an operator pass

Listed in SOP.md section 10 as well, so it does not only live in this PR:

- Daemon install state on **other** fleet nodes (`.100`, `.41`, `.158`, chi cluster). Only this node was checked.
- The launchd plist has never been exercised. Its `ProgramArguments` match the systemd invocation, but there is no macOS node here to confirm it loads.
- Python/JS behavioural parity is asserted by a comment in `constants.py`, never tested. No cross-runtime test exists and the JS suite does not run in CI.
- Whether `openclaw-plugin-python/` can be deleted. Dead by inspection, but removal is out of scope for a docs change.
- `src/feb/generator.js` and `src/love-loader/LoveBootLoader.js` still default to `~/.openclaw/feb` in their own signatures and search lists. Whether anything reaches them with no explicit directory needs a JS-side audit.

## Follow-ups worth a card

1. Wire the JS tests into CI, or delete `test/run-tests.js` (it references three suite files that do not exist). Right now a JS change cannot go red.
2. Fix `daemon/cloud9-daemon.js` `DEFAULT_CONFIG` to call the same sovereign resolver as `src/index.js`.
3. Remove `|| true` from `publish.yml`'s test job, and `if: always()` from the publish jobs, so a failing suite can actually block a release.
4. Delete the `openclaw-plugin-python/` subtree and the now-skipping `publish-npm` job.
5. Flip `docs-check.yml` to `tiers: "1,2,3"` once it has run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsQ1iDAmshJmL3BLUNApMM
