### PR TITLE
ci(docs-check): enable tier 3 so the evidence block actually runs

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,4 +21,4 @@ jobs:
   docs:
     uses: smilinTux/sk-standards/.github/workflows/docs-check.yml@main
     with:
-      tiers: "1,2"
+      tiers: "1,2,3"


### PR DESCRIPTION
Turns on **tier 3**, which executes the `docs-evidence` block on every push and pull request.

Until now this repo ran the gate at `tiers: "1,2"`, which only checks that the 7 required files **exist** and that a PR touching `src/**` also touches `CHANGELOG.md`. The evidence block was written and passing locally, but **nothing executed it in CI**, so a documented port, entry point or config path could drift and no gate would notice. That is the exact "a green check certifies less than it appears" failure the standard exists to close.

Every check in this block is hermetic (repo-local `grep`/`test`, no network, no live host, no toolchain beyond the runner), so tier 3 runs on the stock `docs-check` runner.

**This PR is its own verification.** The `docs / docs-check` run below executes the evidence at the new tier. It is merged only if green, per `DOCS_FRESHNESS_STANDARD` section 2 (never land a gate that starts red).